### PR TITLE
fixing rm.show_association bug when has more than 8 tx

### DIFF
--- a/src/sionna/rt/radio_map_solvers/radio_map.py
+++ b/src/sionna/rt/radio_map_solvers/radio_map.py
@@ -489,7 +489,8 @@ class RadioMap:
         self,
         metric : str = "path_gain",
         show_tx : bool = True,
-        show_rx : bool = False
+        show_rx : bool = False,
+        colors_map = None
         ) -> plt.Figure:
         r"""Visualizes cell-to-tx association for a given metric
 
@@ -515,7 +516,13 @@ class RadioMap:
             raise ValueError("Invalid metric")
 
         # Create the colormap and normalization
-        colors = mpl.colormaps['Dark2'].colors[:self.num_tx]
+        if(colors_map is None):
+            colors_map = mpl.colormaps['Dark2'].colors
+        if(self.num_tx <= len(colors_map)):
+            colors = colors_map[:self.num_tx]
+        else:
+            raise ValueError('Color map is not enough for '+str(self.num_tx)+' only has '+str(len(colors_map))+' colors. Please use parameter colors_map to provide more colors.')
+        
         cmap, norm = from_levels_and_colors(
             list(range(self.num_tx+1)), colors)
         fig_tx = plt.figure()


### PR DESCRIPTION
This is my first time to submit a pull request
I am sorry I delete my old pull request because I realize it is better to put colorsmap as parameter, so user can choose which color they want

In my case I use different project to generate my distinct color
(source: https://github.com/alan-turing-institute/distinctipy)


How to reproduce the bug?
put more than 8 tx on a scene, do rm_solver, and rm.show_association()
it will return error because the color map only contains 8 color max

Reason?
I need to show a tx range for multiple tx, so that I know in this area, which tx is stronger and which area is not covered by any of the tx

Fixes a bug?
yes, by adding a new parameter colors_map we can add more color

Adds a new Feature?
adding customize colors_map to rm.show_association