### PR TITLE
Add show orientations to scene.render() 

### DIFF
--- a/src/sionna/rt/renderer.py
+++ b/src/sionna/rt/renderer.py
@@ -13,13 +13,14 @@ import numpy as np
 from  sionna import rt
 from .utils import make_render_sensor, paths_to_segments, unmultiply_alpha, \
                    twosided_diffuse, radio_map_to_textured_rectangle, \
-                   scoped_set_log_level, scene_scale
+                   rotation_matrix, scoped_set_log_level, scene_scale
 
 
 def render(scene: rt.Scene,
            camera: str | rt.Camera | mi.ScalarTransform4f | mi.Sensor,
            paths: rt.Paths | None,
            show_devices: bool,
+           show_orientations: bool,
            num_samples: int, resolution: tuple[int, int], fov: float = 45,
            clip_at: float | None = None,
            clip_plane_orientation: tuple[float, float, float] = (0, 0, -1),
@@ -51,6 +52,10 @@ def render(scene: rt.Scene,
 
     show_devices : bool
         If `paths` is not `None`, shows the radio devices.
+
+    show_orientations : bool
+        If set to `True`, the orientation of the radio device is shown using
+        a line.
 
     radio_map : :class:`~sionna.rt.RadioMap` | `None`
         An optional coverage map to overlay in the scene for visualization.
@@ -142,6 +147,7 @@ def render(scene: rt.Scene,
         overlay_scene = get_overlay_scene(
             scene, sensor, paths=paths,
             show_sources=show_devices, show_targets=show_devices,
+            show_orientations=show_orientations,
             radio_map=radio_map,
            rm_tx=rm_tx, rm_db_scale=rm_db_scale,
            rm_vmin=rm_vmin, rm_vmax=rm_vmax, rm_metric=rm_metric
@@ -298,6 +304,7 @@ def visual_scene_from_wireless_scene(scene: rt.Scene,
 # pylint: disable=line-too-long
 def get_overlay_scene(scene: rt.Scene, sensor: mi.Sensor, paths: any | None = None,
                       show_sources: bool = True, show_targets: bool = True,
+                      show_orientations: bool = False,
                       radio_map: rt.CoverageMap | None = None,
                       rm_tx: int | str | None = None, rm_db_scale: bool = True,
                       rm_vmin: float | None = None, rm_vmax: float | None = None,
@@ -312,6 +319,7 @@ def get_overlay_scene(scene: rt.Scene, sensor: mi.Sensor, paths: any | None = No
     if sc == 0.:
         sc = 1.
     radius = max(0.005 * sc, 0.5)
+    orientatiton_radius = min(0.005 * sc, 0.2)
 
     # TODO: should use the source and target positions from the `paths` object
     # if given?
@@ -338,6 +346,25 @@ def get_overlay_scene(scene: rt.Scene, sensor: mi.Sensor, paths: any | None = No
                     'radiance': {'type': 'rgb', 'value': rd.color},
                 },
             }
+
+            if show_orientations:
+                line_length = 0.25 * sc
+                head_length = 0.05 * line_length
+
+                rot_mat = rotation_matrix(rd.orientation)
+                local_endpoint = mi.Point3f(line_length, 0.0, 0.0)
+                endpoint = rd.position + rot_mat @ local_endpoint
+
+                result[f"rd-{prefix}-{name}-line"] = {
+                    "type": "cylinder",
+                    "p0": dr.ravel(rd.position),
+                    "p1": dr.ravel(endpoint),
+                    "radius": orientatiton_radius,
+                    "light": {
+                        "type": "area",
+                        "radiance": {"type": "rgb", "value": rd.color},
+                    },
+                }
 
     # --- Paths, shown as cylinders (the closest we have to lines)
     if paths is not None:

--- a/src/sionna/rt/scene.py
+++ b/src/sionna/rt/scene.py
@@ -522,7 +522,8 @@ class Scene:
         rm_tx: int | str | None = None,
         rm_vmax: float | None = None,
         rm_vmin: float | None = None,
-        show_devices: bool = True
+        show_devices: bool = True,
+        show_orientations: bool = False,
     ) -> plt.Figure | mi.Bitmap:
         # pylint: disable=line-too-long
         r"""Renders the scene from the viewpoint of a camera or the interactive viewer
@@ -583,12 +584,16 @@ class Scene:
             set to `True`, or in linear scale otherwise.
 
         :param show_devices: Show radio devices
+
+        :param show_orientations: If set to `True`, the orientation of
+            the radio device is shown using a line. Defaults to `False`.
         """
         image = render(
             scene=self,
             camera=camera,
             paths=paths,
             show_devices=show_devices,
+            show_orientations=show_orientations,
             clip_at=clip_at,
             clip_plane_orientation=clip_plane_orientation,
             radio_map=radio_map,
@@ -668,7 +673,8 @@ class Scene:
         rm_tx: int | str | None=None,
         rm_vmin: float | None=None,
         rm_vmax: float | None=None,
-        show_devices: bool=True
+        show_devices: bool=True,
+        show_orientations: bool=False
     ) -> mi.Bitmap:
         # pylint: disable=line-too-long
         r"""Renders the scene from the viewpoint of a camera or the interactive
@@ -729,12 +735,16 @@ class Scene:
             set to `True`, or in linear scale otherwise.
 
         :param show_devices: Show radio devices
+
+        :param show_orientations: If set to `True`, the orientation of
+            the radio device is shown using a line. Defaults to `False`.
         """
         image = render(
             scene=self,
             camera=camera,
             paths=paths,
             show_devices=show_devices,
+            show_orientations=show_orientations,
             clip_at=clip_at,
             clip_plane_orientation=clip_plane_orientation,
             radio_map=radio_map,

--- a/test/unit/test_render.py
+++ b/test/unit/test_render.py
@@ -156,3 +156,50 @@ def test03_render_to_file_with_vertical_cut_plane():
                   & (mean_color[[0, 1]] <= 0.38 * 255))
     assert mean_color[2] >= 0.5 * 255
     assert mean_color[3] >= 0.95 * 255
+
+
+def test04_render_with_device_orientations():
+    scene = load_scene(rt.scene.box_two_screens)
+    # Set the material properties.
+    eta_r, sigma = itu_material("metal", 3e9) # ITU material evaluated at 3GHz
+    for sh in scene.mi_scene.shapes():
+        material = sh.bsdf().radio_material
+        material.relative_permittivity = eta_r
+        material.conductivity = sigma
+        material.scattering_coefficient = 0.01
+        material.xpd_coefficient = 0.2
+
+    add_example_radio_devices(scene)
+    paths = get_example_paths(scene)
+    radio_map = get_example_radio_map(scene)
+
+    # Camera pose to render from
+    bbox = scene.mi_scene.bbox()
+    to_world = mi.ScalarTransform4f().look_at(
+        origin=mi.ScalarVector3f(1.3, 1.0, 1.5) * bbox.max,
+        target=mi.ScalarVector3f(1, 1, 0) * bbox.center(),
+        up=[0, 0, 1],
+    )
+
+    image: mi.Bitmap = scene.render(
+        camera=to_world,
+        resolution=(256, 256), num_samples=4, fov=70,
+        show_devices=True,
+        show_orientations=True,
+        clip_at=0.9 * scene.mi_scene.bbox().max.z,
+        lighting_scale=1.5, return_bitmap=True)
+
+    # fname = join(tempfile.gettempdir(), "scene.png")
+    # image.convert(pixel_format=mi.Bitmap.PixelFormat.RGBA, \
+    #             component_format=mi.Struct.Type.UInt8, srgb_gamma=True) \
+    #     .write(fname)
+    # print(f"[+] Rendering saved to: {fname}")
+
+    # It's too brittle to specify the exact result per pixel, so we assert
+    # on the proportion of colors instead.
+    image_np = np.array(image, copy=False)
+    green_line = np.mean(image_np[-70:-50, :35], axis=(0, 1))
+    assert np.all(green_line > [0.066, 0.132, 0.066, 0.165])
+
+    yellow_line = np.mean(image_np[80:120, 20:50], axis=(0, 1))
+    assert np.all(yellow_line > [0.207, 0.207, 0.158, 0.999])


### PR DESCRIPTION
Implementation of #14. Borrow from `Previewer.plot_radio_devices()`, but omit the arrow.