### PR TITLE
chore(docs): fix typo about rotation angle in EM primer

### DIFF
--- a/doc/source/em_primer.rst
+++ b/doc/source/em_primer.rst
@@ -117,7 +117,7 @@ where
                    -\hat{k}_y &  \hat{k}_x &          0
                  \end{bmatrix}\\
     \hat{\mathbf{k}} &= \frac{\hat{\mathbf{a}} \times \hat{\mathbf{b}}}{\lVert \hat{\mathbf{a}} \times \hat{\mathbf{b}} \rVert}\\
-    \theta &=\hat{\mathbf{a}}^\mathsf{T}\hat{\mathbf{b}}
+    \cos\(\theta\) &=\hat{\mathbf{a}}^\mathsf{T}\hat{\mathbf{b}}
 
 such that :math:`\mathbf{R}(\hat{\mathbf{a}}, \hat{\mathbf{b}})\hat{\mathbf{a}}=\hat{\mathbf{b}}`.
 


### PR DESCRIPTION
Hi, I think I found a typo in the docs, as you probably meant that the dot product defines the cosine of the angle (and not the angle itself). Let me know if I am wrong :-)