### PR TITLE
Update field_calculator.py

### DIFF
--- a/src/sionna/rt/path_solvers/field_calculator.py
+++ b/src/sionna/rt/path_solvers/field_calculator.py
@@ -306,14 +306,13 @@ class FieldCalculator:
             # If a diffuse reflection is sampled, then it is set to 2PI.
             # Otherwise it is left unchanged
             solid_angle = dr.select(diffuse, dr.two_pi, solid_angle)
-
+            ki_world = dr.select(active, ko_world, ki_world)
             # Prepare for next iteration
             depth += 1
             active &= (depth <= max_depth) & ~next_is_none
             normal = dr.copy(si_scene.n)
             prev_vertex = dr.copy(vertex)
             vertex = dr.copy(next_vertex)
-            ki_world = dr.select(active, ko_world, ki_world)
             interaction_type = dr.copy(next_interaction_type)
 
         # Scaling to apply free-space propagation loss


### PR DESCRIPTION
Fixed a bug. The bug occurs on the class "FieldCalculator", which makes NLOS paths get wrong arrival angles, causing wrong extractions of incident e-field values. The incident e-field values are named as "tgt_patterns" in class "FieldCalculator".
The accurate position is in the loop "while dr.hint(active, mode=self.loop_mode, exclude=[wavelength]):" in the method "_compute_cir": "ki_world = dr.select(active, ko_world, ki_world)" should be placed before "active &= (depth <= max_depth) & ~next_is_none". tgt_patterns is directly affected by ki_world: "# Receive antenna pattern tgt_patterns = [antenna_pattern_to_world_implicit(tgt_antenna_pattern, tgt_to_world, -ki_world, direction="in") for tgt_antenna_pattern in tgt_antenna_patterns]", the original code would get the next active, causing a wrong operation "ki_world = ki_world", the right operation should be "ki_world = ko_world".