### PR TITLE
Add radio map solver for terrain specified by a heightmap

### DIFF
--- a/doc/source/api/radio_maps.rst
+++ b/doc/source/api/radio_maps.rst
@@ -26,6 +26,10 @@ of random positions within the scene that have sufficient path gain, RSS, or SIN
     :members:
     :exclude-members: finalize, add
 
+.. autoclass:: sionna.rt.DemRadioMap
+    :members:
+    :exclude-members: finalize, add
+
 .. autoclass:: sionna.rt.RadioMap
     :members:
     :exclude-members: finalize, add

--- a/src/sionna/rt/__init__.py
+++ b/src/sionna/rt/__init__.py
@@ -35,7 +35,7 @@ from .constants import InteractionType,\
                        INVALID_SHAPE,\
                        INVALID_PRIMITIVE
 from .path_solvers import PathSolver, Paths
-from .radio_map_solvers import RadioMapSolver, PlanarRadioMap, MeshRadioMap, RadioMap
+from .radio_map_solvers import RadioMapSolver, PlanarRadioMap, MeshRadioMap, DemRadioMap, RadioMap
 from .preview import Previewer
 from .scene_object import SceneObject
 from .sliced_integrator import SlicedPathIntegrator, SlicedDepthIntegrator

--- a/src/sionna/rt/preview.py
+++ b/src/sionna/rt/preview.py
@@ -474,6 +474,60 @@ class Previewer:
         mesh = p3s.Mesh(geometry, material)
         self._add_child(mesh, pmin, pmax, persist=False)
 
+    def plot_dem_radio_map(self, radio_map, tx=0, db_scale=True,
+                            vmin=None, vmax=None, metric="path_gain"):
+        """
+        Plot the radio map as a textured mesh in the scene.
+        """
+        meas_surface: mi.Mesh = radio_map.measurement_surface
+        vertices = dr.reshape(dtype=mi.Point3f,
+                              value=meas_surface.vertex_positions_buffer(),
+                              shape=(3, meas_surface.vertex_count()))
+        texcoords = dr.reshape(dtype=mi.Point2f,
+                               value=meas_surface.vertex_texcoords_buffer(),
+                               shape=(2, meas_surface.vertex_count()))
+        faces = dr.reshape(dtype=mi.Vector3u,
+                           value=meas_surface.faces_buffer(),
+                           shape=(3, meas_surface.face_count()))
+        # Transpose since .numpy() gives arrays with shape (ndim, -1)
+        position_np = vertices.numpy().T
+        index_np = faces.numpy().T
+        uv_np = texcoords.numpy().T
+
+        geo = p3s.BufferGeometry(
+            attributes={
+                "position": p3s.BufferAttribute(position_np, normalize=False),
+                "index": p3s.BufferAttribute(index_np.ravel(), normalize=False),
+                "uv": p3s.BufferAttribute(uv_np, normalize=False)
+            }
+        )
+
+        tensor = radio_map.transmitter_radio_map(metric, tx).numpy()
+        to_map, normalizer, color_map = self._coverage_map_color_mapping(
+            tensor, db_scale=db_scale, vmin=vmin, vmax=vmax
+        )
+        texture = color_map(normalizer(to_map)).astype(np.float32)
+        texture[:, :, 3] = (tensor > 0.0).astype(np.float32)
+
+        texture = p3s.DataTexture(
+            data=(np.power(texture, 1/2.2)).astype(np.float32),
+            format="RGBAFormat",
+            type="FloatType",
+            magFilter="NearestFilter",
+            minFilter="NearestFilter",
+            encoding="sRGBEncoding"
+        )
+
+        mat = p3s.MeshLambertMaterial(side="DoubleSide",
+                                      map=texture,
+                                      transparent=True)
+        mesh = p3s.Mesh(geo, mat)
+
+        meas_surface.recompute_bbox()
+        bbox = meas_surface.bbox()
+        pmin, pmax = bbox.min, bbox.max
+        self._add_child(mesh, pmin, pmax, persist=False)
+
     def plot_scene(self):
         """
         Plots the meshes that make the scene

--- a/src/sionna/rt/radio_map_solvers/__init__.py
+++ b/src/sionna/rt/radio_map_solvers/__init__.py
@@ -8,4 +8,5 @@
 from .radio_map_solver import RadioMapSolver
 from .planar_radio_map import PlanarRadioMap
 from .mesh_radio_map import MeshRadioMap
+from .dem_radio_map import DemRadioMap
 from .radio_map import RadioMap

--- a/src/sionna/rt/radio_map_solvers/dem_radio_map.py
+++ b/src/sionna/rt/radio_map_solvers/dem_radio_map.py
@@ -23,6 +23,28 @@ def _resample_tensor(tensor: mi.TensorXf, res: mi.Point2u):
     return dr.reshape(mi.TensorXf, resampled, res)
 
 class DemRadioMap(RadioMap):
+    r"""
+    DEM Radio Map
+
+    A DEM-based radio map is computed by a 
+    :doc:`radio map solver <radio_map_solvers>` for a measurement surface
+    defined by a Digital Elevation Model (DEM), also known as a heightmap.
+    The DEM is resampled to the required resolution for the given cell size,
+    and then triangulated to make the measurement surface. Unlike 
+    :class:`~.rt.MeshRadioMap`, this radio map exposes its values as a 2D grid
+    draped over the measurement surface.
+
+    :param scene: Scene for which the radio map is computed
+
+    :param elevation: DEM to use. May be resampled.
+
+    :param cell_size: Size of a cell of the radio map [m]
+
+    :param center: Center of the radio map :math:`(x,y,z)` [m] as a 
+        three-dimensional vector
+
+    :param size:  Size of the radio map [m]
+    """
     def __init__(self,
                  scene : "Scene",
                  elevation : mi.TensorXf,
@@ -62,8 +84,9 @@ class DemRadioMap(RadioMap):
 
         # Builds the Mitsuba mesh modeling the measurement surface
         elevation_resolution = self._cells_per_dim + mi.Point2u(1, 1)
-        self._elevation = _resample_tensor(elevation, elevation_resolution)
-        self._meas_surface = triangulate_elevation(self._elevation, center, size)
+        elevation = _resample_tensor(elevation, elevation_resolution)
+        self._meas_surface = triangulate_elevation(elevation, center, size)
+        self._elevation = elevation
 
         cells_per_dim = self._cells_per_dim
         pathgain_shape = (self.num_tx, cells_per_dim.y[0], cells_per_dim.x[0])
@@ -110,7 +133,7 @@ class DemRadioMap(RadioMap):
         # It makes more sense to use eval_parameterization() here, but that
         # segfaults for common inputs (cause unknown). This is a workaround
         # leveraging the fact that triangulate_elevation() creates texcoords
-        # by flattening the vertices to a unit square in the XY plane. This 
+        # by flattening the vertices to a unit square in the XY plane. This
         # will not work if elevation values are negative.
         scene = mi.load_dict({"type": "scene", "mesh": self._meas_surface})
         points = scene.ray_intersect(ray).p
@@ -119,6 +142,7 @@ class DemRadioMap(RadioMap):
 
     @property
     def path_gain(self):
+        # pylint: disable=line-too-long
         r"""Path gains across the radio map from all transmitters
 
         :type: :py:class:`mi.TensorXf [num_tx, cells_per_dim_y, cells_per_dim_x]`
@@ -229,6 +253,13 @@ class DemRadioMap(RadioMap):
         return self._cells_per_dim
 
     def resample(self, cell_size: mi.Point2f | None = None):
+        r"""Resamples the DEM and path gain tensors to the given resolution.
+
+        :param cell_size: The desired resampled resolution. Cannot be smaller
+            than the cell size used to generate the radio map originally. 
+            Providing :py:class:`None` will reset these tensors to their
+            original values.
+        """
         original_shape = mi.Point2f(self._original_pathgain_map.shape[1:])
         original_cell_size = self._size / original_shape
         if cell_size is None:

--- a/src/sionna/rt/radio_map_solvers/dem_radio_map.py
+++ b/src/sionna/rt/radio_map_solvers/dem_radio_map.py
@@ -52,21 +52,60 @@ class DemRadioMap(MeshRadioMap):
             elevation = mi.TensorXf(elevation)
 
         # Number of cells
-        cells_per_dim = mi.Point2u(elevation.shape[1] - 1,
-                                   elevation.shape[0] - 1)
+        cells_per_dim = mi.Point2u(elevation.shape[1], elevation.shape[0])
 
         # Builds the Mitsuba mesh modeling the measurement surface
         meas_surface = triangulate_elevation(elevation)
+        center = mi.Point3f(center)
+        orientation = mi.Point3f(orientation)
+        orientation_deg = orientation * 180. / dr.pi
+        size = mi.Point2f(size)
+        to_world = mi.Transform4f().translate(center) \
+                                .rotate([0., 0., 1.], orientation_deg.x) \
+                                .rotate([0., 1., 0.], orientation_deg.y) \
+                                .rotate([1., 0., 0.], orientation_deg.z) \
+                                .scale([0.5 * size.x, 0.5 * size.y, 1])
         params = mi.traverse(meas_surface)
-        params["to_world"] = self.to_world
+        # Apply the to_world transformation
+        vertices = dr.reshape(mi.Point3f, params["vertex_positions"], (3, -1))
+        vertices = to_world @ vertices
+        params["vertex_positions"] = dr.ravel(vertices)
+
         params.update()
         super().__init__(scene, meas_surface=meas_surface)
 
         self._elevation = elevation
         self._cells_per_dim = cells_per_dim
-        self._center = mi.Point3f(center)
-        self._orientation = mi.Point3f(orientation)
-        self._size = mi.Point2f(size)
+        self._center = center
+        self._orientation = orientation
+        self._size = size
+
+    @property
+    def center(self):
+        r"""Center of the radio map in the global coordinate system
+
+        :type: :py:class:`mi.Point3f`
+        """
+        return self._center
+
+    @property
+    def orientation(self):
+        r"""Orientation of the radio map :math:`(\alpha, \beta, \gamma)`
+        specified through three angles corresponding to a 3D rotation as defined
+        in :eq:`rotation`. An orientation of :math:`(0,0,0)` corresponds to a
+        radio map that is parallel to the XY plane.
+
+        :type: :py:class:`mi.Point3f`
+        """
+        return self._orientation
+
+    @property
+    def size(self):
+        r"""Size of the radio map [m]
+
+        :type: :py:class:`mi.Point2f`
+        """
+        return self._size
 
     @property
     def elevation(self):
@@ -123,40 +162,35 @@ class DemRadioMap(MeshRadioMap):
         super().finalize()
         # [num_tx, 2 * cells_per_dim_y * cells_per_dim_x]
         pathgain_map = self._pathgain_map
-        all_idx = dr.arange(mi.UInt, size=len(pathgain_map.array))
-        # There are two faces for a cell. If one face was originally nan,
-        # the cell's value should be the value of the other face. Assumes that
-        # values are non-infinite.
-        dr.scatter(
-            target=pathgain_map,
-            value=float("-inf"),
-            index=all_idx,
-            active=dr.isnan(pathgain_map),
-        )
-        # [num_tx, 2 * cells_per_dim_y * cells_per_dim_x]
-        pathgain_map = dr.block_reduce(
-            op=dr.ReduceOp.Max,
-            value=pathgain_map,
-            block_size=2,
-        )
-        # [num_tx, cells_per_dim_y * cells_per_dim_x]
-        pathgain_map = dr.block_sum(pathgain_map, 2) / 2
-        dr.scatter(
-            target=pathgain_map,
-            value=float("nan"),
-            index=all_idx,
-            # There is no way to check specifically for -inf
-            active=dr.isinf(pathgain_map) & (pathgain_map < 0),
-        )
-
         cells_per_dim_x = self._cells_per_dim.x[0]
         cells_per_dim_y = self._cells_per_dim.y[0]
-        # [num_tx, cells_per_dim_y, cells_per_dim_x]
-        pathgain_map = dr.reshape(
-            dtype=mi.TensorXf,
-            value=pathgain_map,
-            shape=(self.num_tx, cells_per_dim_y, cells_per_dim_x))
-        self._pathgain_map = pathgain_map
+        grid_shape = (self.num_tx, cells_per_dim_y, cells_per_dim_x)
+        pathgain_map_grid = dr.zeros(mi.TensorXf, shape=grid_shape)
+
+        num_faces = len(pathgain_map.array)
+        upper_indices = dr.arange(mi.UInt, start=0, stop=num_faces // 2)
+        lower_indices = dr.arange(mi.UInt, start=num_faces // 2, stop=num_faces)
+        # [num_tx * cells_per_dim_y * cells_per_dim_x]
+        all_grid_indices = dr.arange(mi.UInt, size=len(pathgain_map_grid.array))
+        # [num_tx * cells_per_dim_y * cells_per_dim_x]
+        upper_face_values = dr.gather(mi.Float, pathgain_map.array, upper_indices)
+        # [num_tx * cells_per_dim_y * cells_per_dim_x]
+        lower_face_values = dr.gather(mi.Float, pathgain_map.array, lower_indices)
+        # TODO make this work for multiple transmitters
+        dr.scatter_add(target=pathgain_map_grid.array,
+                       value=upper_face_values,
+                       index=all_grid_indices,
+                       active=~dr.isnan(upper_face_values))
+        dr.scatter_add(target=pathgain_map_grid.array,
+                       value=lower_face_values,
+                       index=all_grid_indices,
+                       active=~dr.isnan(lower_face_values))
+        # [num_tx * cells_per_dim_y * cells_per_dim_x]
+        count = dr.zeros(mi.TensorXu, grid_shape)
+        dr.scatter_add(count.array, 1, all_grid_indices, ~dr.isnan(upper_face_values))
+        dr.scatter_add(count.array, 1, all_grid_indices, ~dr.isnan(lower_face_values))
+        pathgain_map_grid /= count
+        self._pathgain_map = pathgain_map_grid
 
     def resample(self, resolution: mi.Point2u):
         resolution = mi.Point2u(resolution)
@@ -170,23 +204,3 @@ class DemRadioMap(MeshRadioMap):
         bitmap = mi.Bitmap(self._elevation, mi.Bitmap.PixelFormat.Y)
         resampled = mi.TensorXf(bitmap.resample(resolution))
         self._elevation = dr.reshape(mi.TensorXf, resampled, shape)
-
-    @property
-    def to_world(self):
-        r"""Transform that maps a unit square in the X-Y plane to the rectangle
-        that defines the radio map's base
-
-        :type: :py:class:`mi.Transform4f`
-        """
-
-        center = self.center
-        orientation = self.orientation
-        size = self.size
-
-        orientation_deg = orientation * 180. / dr.pi
-        to_world = mi.Transform4f().translate(center) \
-                                .rotate([0., 0., 1.], orientation_deg.x) \
-                                .rotate([0., 1., 0.], orientation_deg.y) \
-                                .rotate([1., 0., 0.], orientation_deg.z) \
-                                .scale([0.5 * size.x, 0.5 * size.y, 1])
-        return to_world

--- a/src/sionna/rt/radio_map_solvers/dem_radio_map.py
+++ b/src/sionna/rt/radio_map_solvers/dem_radio_map.py
@@ -1,0 +1,192 @@
+"""Digital Elevation Model (DEM) radio map"""
+
+import mitsuba as mi
+import drjit as dr
+
+from .mesh_radio_map import MeshRadioMap
+from sionna.rt.utils.geometry import triangulate_elevation
+from typing import override, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..scene import Scene
+
+class DemRadioMap(MeshRadioMap):
+    def __init__(self,
+                 scene : "Scene",
+                 elevation: mi.TensorXf,
+                 center : mi.Point3f | None = None,
+                 orientation : mi.Point3f | None = None,
+                 size : mi.Point2f | None = None):
+
+        # Check the properties of the rectangle defining the radio map's base
+        if (center is None) and (size is None) and (orientation is None):
+            # Default value for center: Center of the scene
+            # Default value for the scale: Just enough to cover all the scene
+            # with axis-aligned edges of the rectangle
+            # [min_x, min_y, min_z]
+            scene_min = scene.mi_scene.bbox().min
+            # In case of empty scene, bbox min is -inf
+            scene_min = dr.select(dr.isinf(scene_min), -1.0, scene_min)
+            # [max_x, max_y, max_z]
+            scene_max = scene.mi_scene.bbox().max
+            # In case of empty scene, bbox min is inf
+            scene_max = dr.select(dr.isinf(scene_max), 1.0, scene_max)
+            # Center and size
+            center = 0.5 * (scene_min + scene_max)
+            center.z = 1.5
+            size = (scene_max - scene_min).xy
+            # Set the orientation to default value
+            orientation = dr.zeros(mi.Point3f, 1)
+        elif ((center is None) or (size is None) or (orientation is None)):
+            raise ValueError("If one of `center`, `orientation`," \
+                             " or `size` is not None, then all of them" \
+                             " must not be None.")
+        else:
+            center = mi.Point3f(center)
+            orientation = mi.Point3f(orientation)
+            size = mi.Point2f(size)
+
+        if len(dr.shape(elevation)) != 2:
+            raise ValueError("Elevation must be a 2D tensor.")
+        else:
+            elevation = mi.TensorXf(elevation)
+
+        # Number of cells
+        cells_per_dim = mi.Point2u(elevation.shape[1] - 1,
+                                   elevation.shape[0] - 1)
+
+        # Builds the Mitsuba mesh modeling the measurement surface
+        meas_surface = triangulate_elevation(elevation)
+        params = mi.traverse(meas_surface)
+        params["to_world"] = self.to_world
+        params.update()
+        super().__init__(scene, meas_surface=meas_surface)
+
+        self._elevation = elevation
+        self._cells_per_dim = cells_per_dim
+        self._center = mi.Point3f(center)
+        self._orientation = mi.Point3f(orientation)
+        self._size = mi.Point2f(size)
+
+    @property
+    def elevation(self):
+        r"""The elevation map used to create the measurement surface
+        
+        :type: :py:class:`mi.TensorXf` [samples_per_dim_y, samples_per_dim_x]
+        """
+        return self._elevation
+
+    @property
+    @override
+    def cells_count(self):
+        r"""Total number of cells in the radio map
+
+        :type: :py:class:`int`
+        """
+        cells_per_dim = self._cells_per_dim
+        return cells_per_dim.x[0] * cells_per_dim.y[0]
+
+    @property
+    def cells_per_dim(self):
+        r"""Number of cells per dimension
+
+        :type: :py:class:`mi.Point2u`
+        """
+        return self._cells_per_dim
+
+    @property
+    @override
+    def cell_centers(self):
+        r"""Positions of the centers of the cells in the global coordinate
+        system.
+
+        :type: :py:class:`mi.TensorXf [cells_per_dim_y, cells_per_dim_x, 3]`
+        """
+        # TODO create UV coordinates in a unit grid with the correct number of cells
+        grid = ...
+        points = self._meas_surface.eval_parameterization(grid)
+        shape = (self._cells_per_dim.y[0], self._cells_per_dim.x[0], 3)
+        return dr.reshape(mi.TensorXf, points, shape)
+
+
+    @property
+    @override
+    def path_gain(self):
+        r"""Path gains across the radio map from all transmitters
+
+        :type: :py:class:`mi.TensorXf [num_tx, cells_per_dim_y, cells_per_dim_x]`
+        """
+        return self._pathgain_map
+
+    def finalize(self) -> None:
+        r"""Finalizes the computation of the radio map"""
+        super().finalize()
+        # [num_tx, 2 * cells_per_dim_y * cells_per_dim_x]
+        pathgain_map = self._pathgain_map
+        all_idx = dr.arange(mi.UInt, size=len(pathgain_map.array))
+        # There are two faces for a cell. If one face was originally nan,
+        # the cell's value should be the value of the other face. Assumes that
+        # values are non-infinite.
+        dr.scatter(
+            target=pathgain_map,
+            value=float("-inf"),
+            index=all_idx,
+            active=dr.isnan(pathgain_map),
+        )
+        # [num_tx, 2 * cells_per_dim_y * cells_per_dim_x]
+        pathgain_map = dr.block_reduce(
+            op=dr.ReduceOp.Max,
+            value=pathgain_map,
+            block_size=2,
+        )
+        # [num_tx, cells_per_dim_y * cells_per_dim_x]
+        pathgain_map = dr.block_sum(pathgain_map, 2) / 2
+        dr.scatter(
+            target=pathgain_map,
+            value=float("nan"),
+            index=all_idx,
+            # There is no way to check specifically for -inf
+            active=dr.isinf(pathgain_map) & (pathgain_map < 0),
+        )
+
+        cells_per_dim_x = self._cells_per_dim.x[0]
+        cells_per_dim_y = self._cells_per_dim.y[0]
+        # [num_tx, cells_per_dim_y, cells_per_dim_x]
+        pathgain_map = dr.reshape(
+            dtype=mi.TensorXf,
+            value=pathgain_map,
+            shape=(self.num_tx, cells_per_dim_y, cells_per_dim_x))
+        self._pathgain_map = pathgain_map
+
+    def resample(self, resolution: mi.Point2u):
+        resolution = mi.Point2u(resolution)
+        self._cells_per_dim = resolution
+        shape = (resolution.y[0], resolution.x[0])
+        # Resize the pathgain map
+        bitmap = mi.Bitmap(self._pathgain_map, mi.Bitmap.PixelFormat.Y)
+        resampled = mi.TensorXf(bitmap.resample(resolution))
+        self._pathgain_map = dr.reshape(mi.TensorXf, resampled, shape)
+        # Resize the stored elevation map
+        bitmap = mi.Bitmap(self._elevation, mi.Bitmap.PixelFormat.Y)
+        resampled = mi.TensorXf(bitmap.resample(resolution))
+        self._elevation = dr.reshape(mi.TensorXf, resampled, shape)
+
+    @property
+    def to_world(self):
+        r"""Transform that maps a unit square in the X-Y plane to the rectangle
+        that defines the radio map's base
+
+        :type: :py:class:`mi.Transform4f`
+        """
+
+        center = self.center
+        orientation = self.orientation
+        size = self.size
+
+        orientation_deg = orientation * 180. / dr.pi
+        to_world = mi.Transform4f().translate(center) \
+                                .rotate([0., 0., 1.], orientation_deg.x) \
+                                .rotate([0., 1., 0.], orientation_deg.y) \
+                                .rotate([1., 0., 0.], orientation_deg.z) \
+                                .scale([0.5 * size.x, 0.5 * size.y, 1])
+        return to_world

--- a/src/sionna/rt/radio_map_solvers/dem_radio_map.py
+++ b/src/sionna/rt/radio_map_solvers/dem_radio_map.py
@@ -10,14 +10,26 @@ from typing import List, TYPE_CHECKING
 if TYPE_CHECKING:
     from ..scene import Scene
 
+def _resample_tensor(tensor: mi.TensorXf, res: mi.Point2u):
+    if tensor.ndim != 2:
+        raise ValueError("_resample_tensor requires tensor to be 2D.")
+    # The resample() function needs this to be the scalar type
+    res = mi.ScalarPoint2u(res.x[0], res.y[0])
+    if dr.all(mi.ScalarPoint2u(tensor.shape) == res):
+        # Resampling to current size is a no-op
+        return tensor
+    bitmap = mi.Bitmap(tensor, mi.Bitmap.PixelFormat.Y)
+    resampled = mi.TensorXf(bitmap.resample(res))
+    return dr.reshape(mi.TensorXf, resampled, res)
+
 class DemRadioMap(RadioMap):
     def __init__(self,
                  scene : "Scene",
                  elevation : mi.TensorXf,
-                 cell_size : mi.Point2f,
+                 cell_size : mi.Point2f = None,
                  center : mi.Point3f | None = None,
                  size : mi.Point2f | None = None):
-  
+
         if center is None or size is None:
             # [min_x, min_y, min_z]
             scene_min = scene.mi_scene.bbox().min
@@ -43,7 +55,6 @@ class DemRadioMap(RadioMap):
             elevation = mi.TensorXf(elevation)
 
         super().__init__(scene)
-        # Number of cells
         self._size = size
         self._center = center
         self._cell_size = cell_size
@@ -51,7 +62,7 @@ class DemRadioMap(RadioMap):
 
         # Builds the Mitsuba mesh modeling the measurement surface
         elevation_resolution = self._cells_per_dim + mi.Point2u(1, 1)
-        self._elevation = self._resample_tensor(elevation, elevation_resolution)
+        self._elevation = _resample_tensor(elevation, elevation_resolution)
         self._meas_surface = triangulate_elevation(self._elevation, center, size)
 
         cells_per_dim = self._cells_per_dim
@@ -96,7 +107,7 @@ class DemRadioMap(RadioMap):
         points = self._meas_surface.eval_parameterization(mi.Point2f(u, v))
         shape = (self._cells_per_dim.y[0], self._cells_per_dim.x[0], 3)
         return dr.reshape(mi.TensorXf, points, shape)
-    
+
     @property
     def path_gain(self):
         r"""Path gains across the radio map from all transmitters
@@ -208,13 +219,16 @@ class DemRadioMap(RadioMap):
         """
         return self._cells_per_dim
 
-    def resample(self, cell_size: mi.Point2f):
-        cell_size = mi.Point2f(cell_size)
+    def resample(self, cell_size: mi.Point2f | None = None):
         original_shape = mi.Point2f(self._original_pathgain_map.shape[1:])
         original_cell_size = self._size / original_shape
+        if cell_size is None:
+            cell_size = original_cell_size
+        cell_size = mi.Point2f(cell_size)
         # The new resolution must be at most as large as the provided elevation
         # data. Any more and the resampling leads to significant error. Resolve
-        # this by increasing cell size or using a higher resolution DEM.
+        # this by increasing the target resampled cell size or recomputing the
+        # Radio Map using a smaller cell size.
         if cell_size.x < original_cell_size.x:
             raise ValueError(f"`cell_size.x` must be greater than or equal to "
                              f"{original_cell_size.x[0]}.")
@@ -223,19 +237,16 @@ class DemRadioMap(RadioMap):
                              f"{original_cell_size.y[0]}.")
 
         res = mi.Point2u(dr.ceil(self._size / cell_size))
-        if dr.all(res == original_shape):
-            # Resampling to current size is a no-op
-            return
         self._cells_per_dim = mi.Vector2u(res.x, res.y)
 
         # Resize the pathgain map
         pathgain_map = dr.zeros(mi.TensorXf, (self.num_tx, res.y[0], res.x[0]))
         for tx in range(self.num_tx):
             tmp = self._original_pathgain_map[tx, ...]
-            pathgain_map[tx, ...] = self._resample_tensor(tmp, res).array
+            pathgain_map[tx, ...] = _resample_tensor(tmp, res).array
         self._pathgain_map = pathgain_map
         # Resize the stored elevation map
-        self._elevation = self._resample_tensor(self._original_elevation, res)
+        self._elevation = _resample_tensor(self._original_elevation, res)
 
     ###############################################
     # Internal methods
@@ -270,13 +281,3 @@ class DemRadioMap(RadioMap):
         v1 = meas_surface.vertex_position(prim_index[1])
         v2 = meas_surface.vertex_position(prim_index[2])
         return dr.norm(dr.cross(v1 - v0, v2 - v0)) / 2
-
-
-    def _resample_tensor(self, tensor: mi.TensorXf, res: mi.Point2u):
-        if tensor.ndim != 2:
-            raise ValueError("_resample_tensor requires tensor to be 2D.")
-        # The resample() function needs this to be the scalar type
-        res = mi.ScalarPoint2u(res.x[0], res.y[0])
-        bitmap = mi.Bitmap(tensor, mi.Bitmap.PixelFormat.Y)
-        resampled = mi.TensorXf(bitmap.resample(res))
-        return dr.reshape(mi.TensorXf, resampled, res)

--- a/src/sionna/rt/radio_map_solvers/dem_radio_map.py
+++ b/src/sionna/rt/radio_map_solvers/dem_radio_map.py
@@ -13,7 +13,8 @@ if TYPE_CHECKING:
 class DemRadioMap(MeshRadioMap):
     def __init__(self,
                  scene : "Scene",
-                 elevation: mi.TensorXf,
+                 elevation : mi.TensorXf,
+                 cell_size : mi.Point2f | None = None,
                  center : mi.Point3f | None = None,
                  orientation : mi.Point3f | None = None,
                  size : mi.Point2f | None = None):
@@ -65,9 +66,24 @@ class DemRadioMap(MeshRadioMap):
 
         self._elevation = elevation
         self._cells_per_dim = cells_per_dim
+        if cell_size is None:
+            self._cell_size = mi.Point2f(elevation.shape[1], elevation.shape[0])
+        else:
+            self._cell_size = cell_size
         self._center = center
         self._orientation = orientation
         self._size = size
+
+        res = mi.Point2u(dr.ceil(self._size / self._cell_size))
+        if res.x[0] > elevation.shape[1] or res.y[0] > elevation.shape[0]:
+            # Error here if possible to avoid doing work and then erroring after
+            raise ValueError("The requested cell size is too small. Use a "
+                             "larger cell size or provide higher-resolution "
+                             "elevation data.")
+
+        # Copies to prevent data loss when repeatedly calling resample()
+        self._original_pathgain_map = None
+        self._original_elevation = elevation
 
     @property
     def center(self):
@@ -195,16 +211,38 @@ class DemRadioMap(MeshRadioMap):
                            active=~dr.isnan(lower_face_values))
             pathgain_map_grid /= count
         self._pathgain_map = pathgain_map_grid
+        self._original_pathgain_map = pathgain_map_grid
+        # Resample to have cells of the desired size
+        self.resample(self._cell_size)
 
-    def resample(self, resolution: mi.Point2u):
-        resolution = mi.Point2u(resolution)
-        self._cells_per_dim = resolution
-        shape = (resolution.y[0], resolution.x[0])
+    def resample(self, cell_size: mi.Point2f):
+        cell_size = mi.Point2f(cell_size)
+        original_shape = mi.Point2f(dr.reverse(self._original_elevation.shape))
+        original_cell_size = self._size / original_shape
+        # The new resolution must be at most as large as the provided elevation
+        # data. Any more and the resampling leads to significant error. Resolve
+        # this by increasing cell size or using a higher resolution DEM.
+        if cell_size.x < original_cell_size.x:
+            raise ValueError(f"`cell_size.x` must be greater than or equal to "
+                             f"{original_cell_size.x[0]}.")
+        if cell_size.y < original_cell_size.y:
+            raise ValueError(f"`cell_size.y` must be greater than or equal to "
+                             f"{original_cell_size.y[0]}.")
+
+        res = mi.Point2u(dr.ceil(self._size / cell_size))
+        # The resample() function needs this to be the scalar type
+        res = mi.ScalarPoint2u(res.x[0], res.y[0])
+        self._cells_per_dim = mi.Vector2u(res.x, res.y)
+
         # Resize the pathgain map
-        bitmap = mi.Bitmap(self._pathgain_map, mi.Bitmap.PixelFormat.Y)
-        resampled = mi.TensorXf(bitmap.resample(resolution))
-        self._pathgain_map = dr.reshape(mi.TensorXf, resampled, shape)
+        pathgain_map = dr.zeros(mi.TensorXf, (self.num_tx, *res.yx))
+        for tx in range(self.num_tx):
+            original_pathgain_map = self._original_pathgain_map[tx, ...]
+            bitmap = mi.Bitmap(original_pathgain_map, mi.Bitmap.PixelFormat.Y)
+            resampled = mi.TensorXf(bitmap.resample(res))
+            pathgain_map[tx, ...] = resampled.array
+        self._pathgain_map = pathgain_map
         # Resize the stored elevation map
-        bitmap = mi.Bitmap(self._elevation, mi.Bitmap.PixelFormat.Y)
-        resampled = mi.TensorXf(bitmap.resample(resolution))
-        self._elevation = dr.reshape(mi.TensorXf, resampled, shape)
+        bitmap = mi.Bitmap(self._original_elevation, mi.Bitmap.PixelFormat.Y)
+        resampled = mi.TensorXf(bitmap.resample(res))
+        self._elevation = dr.reshape(mi.TensorXf, resampled, res.yx)

--- a/src/sionna/rt/radio_map_solvers/dem_radio_map.py
+++ b/src/sionna/rt/radio_map_solvers/dem_radio_map.py
@@ -3,27 +3,22 @@
 import mitsuba as mi
 import drjit as dr
 
-from .mesh_radio_map import MeshRadioMap
+from .radio_map import RadioMap
 from sionna.rt.utils.geometry import triangulate_elevation
-from typing import override, TYPE_CHECKING
+from typing import List, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..scene import Scene
 
-class DemRadioMap(MeshRadioMap):
+class DemRadioMap(RadioMap):
     def __init__(self,
                  scene : "Scene",
                  elevation : mi.TensorXf,
-                 cell_size : mi.Point2f | None = None,
+                 cell_size : mi.Point2f,
                  center : mi.Point3f | None = None,
-                 orientation : mi.Point3f | None = None,
                  size : mi.Point2f | None = None):
-
-        # Check the properties of the rectangle defining the radio map's base
-        if (center is None) and (size is None) and (orientation is None):
-            # Default value for center: Center of the scene
-            # Default value for the scale: Just enough to cover all the scene
-            # with axis-aligned edges of the rectangle
+  
+        if center is None or size is None:
             # [min_x, min_y, min_z]
             scene_min = scene.mi_scene.bbox().min
             # In case of empty scene, bbox min is -inf
@@ -33,95 +28,50 @@ class DemRadioMap(MeshRadioMap):
             # In case of empty scene, bbox min is inf
             scene_max = dr.select(dr.isinf(scene_max), 1.0, scene_max)
             # Center and size
-            center = 0.5 * (scene_min + scene_max)
-            center.z = 1.5
-            size = (scene_max - scene_min).xy
-            # Set the orientation to default value
-            orientation = dr.zeros(mi.Point3f, 1)
-        elif ((center is None) or (size is None) or (orientation is None)):
-            raise ValueError("If one of `center`, `orientation`," \
-                             " or `size` is not None, then all of them" \
-                             " must not be None.")
-        else:
-            center = mi.Point3f(center)
-            orientation = mi.Point3f(orientation)
-            size = mi.Point2f(size)
+            if center is None:
+                center = 0.5 * (scene_min + scene_max)
+                center.z = 1.5
+            if size is None:
+                size = (scene_max - scene_min).xy
+        size = mi.Point2f(size)
+        center = mi.Point3f(center)
+        cell_size = mi.Point2f(cell_size)
 
         if len(dr.shape(elevation)) != 2:
             raise ValueError("Elevation must be a 2D tensor.")
         else:
             elevation = mi.TensorXf(elevation)
 
+        super().__init__(scene)
         # Number of cells
-        cells_per_dim = mi.Point2u(elevation.shape[1], elevation.shape[0])
+        self._size = size
+        self._center = center
+        self._cell_size = cell_size
+        self._cells_per_dim = mi.Point2u(size / cell_size)
 
         # Builds the Mitsuba mesh modeling the measurement surface
-        meas_surface = triangulate_elevation(elevation)
-        center = mi.Point3f(center)
-        orientation = mi.Point3f(orientation)
-        size = mi.Point2f(size)
-        # TODO respect the frame
+        elevation_resolution = self._cells_per_dim + mi.Point2u(1, 1)
+        self._elevation = self._resample_tensor(elevation, elevation_resolution)
+        self._meas_surface = triangulate_elevation(self._elevation, center, size)
 
-        super().__init__(scene, meas_surface=meas_surface)
-
-        self._elevation = elevation
-        self._cells_per_dim = cells_per_dim
-        if cell_size is None:
-            self._cell_size = mi.Point2f(elevation.shape[1], elevation.shape[0])
-        else:
-            self._cell_size = cell_size
-        self._center = center
-        self._orientation = orientation
-        self._size = size
-
-        res = mi.Point2u(dr.ceil(self._size / self._cell_size))
-        if res.x[0] > elevation.shape[1] or res.y[0] > elevation.shape[0]:
-            # Error here if possible to avoid doing work and then erroring after
-            raise ValueError("The requested cell size is too small. Use a "
-                             "larger cell size or provide higher-resolution "
-                             "elevation data.")
+        cells_per_dim = self._cells_per_dim
+        pathgain_shape = (self.num_tx, cells_per_dim.y[0], cells_per_dim.x[0])
+        self._pathgain_map = dr.zeros(mi.TensorXf, pathgain_shape)
 
         # Copies to prevent data loss when repeatedly calling resample()
         self._original_pathgain_map = None
-        self._original_elevation = elevation
+        self._original_elevation = self._elevation
 
     @property
-    def center(self):
-        r"""Center of the radio map in the global coordinate system
+    def measurement_surface(self):
+        r"""Mitsuba Mesh corresponding to the
+        radio map measurement surface
 
-        :type: :py:class:`mi.Point3f`
+        :type: :py:class:`mi.Mesh`
         """
-        return self._center
+        return self._meas_surface
 
     @property
-    def orientation(self):
-        r"""Orientation of the radio map :math:`(\alpha, \beta, \gamma)`
-        specified through three angles corresponding to a 3D rotation as defined
-        in :eq:`rotation`. An orientation of :math:`(0,0,0)` corresponds to a
-        radio map that is parallel to the XY plane.
-
-        :type: :py:class:`mi.Point3f`
-        """
-        return self._orientation
-
-    @property
-    def size(self):
-        r"""Size of the radio map [m]
-
-        :type: :py:class:`mi.Point2f`
-        """
-        return self._size
-
-    @property
-    def elevation(self):
-        r"""The elevation map used to create the measurement surface
-        
-        :type: :py:class:`mi.TensorXf` [samples_per_dim_y, samples_per_dim_x]
-        """
-        return self._elevation
-
-    @property
-    @override
     def cells_count(self):
         r"""Total number of cells in the radio map
 
@@ -129,17 +79,8 @@ class DemRadioMap(MeshRadioMap):
         """
         cells_per_dim = self._cells_per_dim
         return cells_per_dim.x[0] * cells_per_dim.y[0]
-
+    
     @property
-    def cells_per_dim(self):
-        r"""Number of cells per dimension
-
-        :type: :py:class:`mi.Point2u`
-        """
-        return self._cells_per_dim
-
-    @property
-    @override
     def cell_centers(self):
         r"""Positions of the centers of the cells in the global coordinate
         system.
@@ -155,10 +96,8 @@ class DemRadioMap(MeshRadioMap):
         points = self._meas_surface.eval_parameterization(mi.Point2f(u, v))
         shape = (self._cells_per_dim.y[0], self._cells_per_dim.x[0], 3)
         return dr.reshape(mi.TensorXf, points, shape)
-
-
+    
     @property
-    @override
     def path_gain(self):
         r"""Path gains across the radio map from all transmitters
 
@@ -166,58 +105,112 @@ class DemRadioMap(MeshRadioMap):
         """
         return self._pathgain_map
 
+    def add(
+        self,
+        e_fields : mi.Vector4f,
+        solid_angle : mi.Float,
+        array_w : List[mi.Float],
+        si_mp : mi.SurfaceInteraction3f,
+        k_world : mi.Vector3f,
+        tx_indices : mi.UInt,
+        hit : mi.Bool
+        ) -> None:
+        r"""
+        Adds the contribution of the rays that hit the measurement surface to 
+        the radio maps
+
+        The radio maps are updated in place.
+
+        :param e_fields: Electric fields as real-valued vectors of dimension 4
+        :param solid_angle: Ray tubes solid angles [sr]
+        :param array_w: Weighting used to model the effect of the transmitter
+            array
+        :param si_mp: Informations about the interaction with the measurement
+            surface
+        :param k_world: Directions of propagation of the rays
+        :param tx_indices: Indices of the transmitters from which the rays
+            originate
+        :param hit: Flags indicating if the rays hit the measurement surface
+        """
+        # Indices of the hit cells
+        cell_ind = self._local_to_cell_ind(si_mp.uv)
+        # Indices of the item in the tensor storing the radio maps
+        tensor_ind = tx_indices * self.cells_count + cell_ind
+
+        # Contribution to the path loss map
+        a = dr.zeros(mi.Vector4f, 1)
+        for e_field, aw in zip(e_fields, array_w):
+            a += aw @ e_field
+        a = dr.squared_norm(a)
+
+        # Ray weight
+        k_local = si_mp.to_local(k_world)
+        cos_theta = dr.abs(k_local.z)
+        w = solid_angle * dr.rcp(cos_theta)
+
+        a *= w
+
+        # Update the path loss map
+        dr.scatter_add(target=self._pathgain_map.array,
+                       value=a,
+                       index=tensor_ind,
+                       active=hit)
+
     def finalize(self) -> None:
         r"""Finalizes the computation of the radio map"""
-        super().finalize()
-        # [num_tx, 2 * cells_per_dim_y * cells_per_dim_x]
-        pathgain_map = self._pathgain_map
+        num_faces = 2 * self.cells_count
         cells_per_dim_x = self._cells_per_dim.x[0]
         cells_per_dim_y = self._cells_per_dim.y[0]
-        grid_shape = (self.num_tx, cells_per_dim_y, cells_per_dim_x)
-        pathgain_map_grid = dr.zeros(mi.TensorXf, shape=grid_shape)
+        # Note: this code is tightly coupled to triangulate_elevation()
+        upper_index = dr.arange(mi.UInt, 0, num_faces // 2)
+        lower_index = dr.arange(mi.UInt, num_faces // 2, num_faces)
+        # Get the area of each cell as the sum of triangle areas
+        upper_area = self._triangle_areas(upper_index)
+        lower_area = self._triangle_areas(lower_index)
+        cell_area = dr.reshape(dtype=mi.TensorXf,
+                                value=upper_area + lower_area,
+                                shape=(cells_per_dim_y, cells_per_dim_x))
+        # Create and apply scaling factor
+        scaling = dr.square(self._wavelength / (4 * dr.pi)) / cell_area
+        self._pathgain_map *= scaling
+        # Set original pathgain map for resampling later
+        self._original_pathgain_map = self._pathgain_map
 
-        num_faces = 2 * self.cells_count
-        # TODO vectorize this over transmitters
-        for tx in range(self.num_tx):
-            idx = mi.UInt(tx * num_faces)
-            upper_indices = idx + dr.arange(mi.UInt, 0, num_faces // 2)
-            lower_indices = idx + dr.arange(mi.UInt, num_faces // 2, num_faces)
-            all_grid_indices = idx + dr.arange(mi.UInt, size=self.cells_count)
-            # [num_tx * cells_per_dim_y * cells_per_dim_x]
-            upper_face_values = dr.gather(dtype=mi.Float,
-                                          source=pathgain_map.array,
-                                          index=upper_indices)
-            # [num_tx * cells_per_dim_y * cells_per_dim_x]
-            lower_face_values = dr.gather(dtype=mi.Float,
-                                          source=pathgain_map.array,
-                                          index=lower_indices)
-            dr.scatter_add(target=pathgain_map_grid.array,
-                           value=upper_face_values,
-                           index=all_grid_indices,
-                           active=~dr.isnan(upper_face_values))
-            dr.scatter_add(target=pathgain_map_grid.array,
-                           value=lower_face_values,
-                           index=all_grid_indices,
-                           active=~dr.isnan(lower_face_values))
-            # [num_tx * cells_per_dim_y * cells_per_dim_x]
-            count = dr.zeros(mi.TensorXu, grid_shape)
-            dr.scatter_add(target=count.array,
-                           value=1,
-                           index=all_grid_indices,
-                           active=~dr.isnan(upper_face_values))
-            dr.scatter_add(target=count.array,
-                           value=1,
-                           index=all_grid_indices,
-                           active=~dr.isnan(lower_face_values))
-            pathgain_map_grid /= count
-        self._pathgain_map = pathgain_map_grid
-        self._original_pathgain_map = pathgain_map_grid
-        # Resample to have cells of the desired size
-        self.resample(self._cell_size)
+    @property
+    def center(self):
+        r"""Center of the radio map in the global coordinate system
+
+        :type: :py:class:`mi.Point3f`
+        """
+        return self._center
+
+    @property
+    def size(self):
+        r"""Size of the radio map [m]
+
+        :type: :py:class:`mi.Point2f`
+        """
+        return self._size
+
+    @property
+    def elevation(self):
+        r"""The elevation map used to create the measurement surface
+        
+        :type: :py:class:`mi.TensorXf` [cells_per_dim_y, cells_per_dim_x]
+        """
+        return self._elevation
+
+    @property
+    def cells_per_dim(self):
+        r"""Number of cells per dimension
+
+        :type: :py:class:`mi.Point2u`
+        """
+        return self._cells_per_dim
 
     def resample(self, cell_size: mi.Point2f):
         cell_size = mi.Point2f(cell_size)
-        original_shape = mi.Point2f(dr.reverse(self._original_elevation.shape))
+        original_shape = mi.Point2f(self._original_pathgain_map.shape[1:])
         original_cell_size = self._size / original_shape
         # The new resolution must be at most as large as the provided elevation
         # data. Any more and the resampling leads to significant error. Resolve
@@ -230,19 +223,60 @@ class DemRadioMap(MeshRadioMap):
                              f"{original_cell_size.y[0]}.")
 
         res = mi.Point2u(dr.ceil(self._size / cell_size))
-        # The resample() function needs this to be the scalar type
-        res = mi.ScalarPoint2u(res.x[0], res.y[0])
+        if dr.all(res == original_shape):
+            # Resampling to current size is a no-op
+            return
         self._cells_per_dim = mi.Vector2u(res.x, res.y)
 
         # Resize the pathgain map
-        pathgain_map = dr.zeros(mi.TensorXf, (self.num_tx, *res.yx))
+        pathgain_map = dr.zeros(mi.TensorXf, (self.num_tx, res.y[0], res.x[0]))
         for tx in range(self.num_tx):
-            original_pathgain_map = self._original_pathgain_map[tx, ...]
-            bitmap = mi.Bitmap(original_pathgain_map, mi.Bitmap.PixelFormat.Y)
-            resampled = mi.TensorXf(bitmap.resample(res))
-            pathgain_map[tx, ...] = resampled.array
+            tmp = self._original_pathgain_map[tx, ...]
+            pathgain_map[tx, ...] = self._resample_tensor(tmp, res).array
         self._pathgain_map = pathgain_map
         # Resize the stored elevation map
-        bitmap = mi.Bitmap(self._original_elevation, mi.Bitmap.PixelFormat.Y)
+        self._elevation = self._resample_tensor(self._original_elevation, res)
+
+    ###############################################
+    # Internal methods
+    ###############################################
+
+    def _local_to_cell_ind(self, p_local : mi.Point2f) -> mi.Int:
+        r"""
+        Computes the indices of the hitted cells of the map from the local
+        :math:`(x,y)` coordinates
+
+        :param p_local: Coordinates of the intersected points in the
+            measurement plane local frame
+
+        :return: Cell indices in the flattened measurement plane
+        """
+
+        # Size of a cell in UV space
+        cell_size_uv = mi.Vector2f(self._cells_per_dim)
+
+        # Cell indices in the 2D measurement plane
+        cell_ind = mi.Point2i(dr.floor(p_local * cell_size_uv))
+
+        # Cell indices for the flattened measurement plane
+        cell_ind = cell_ind[1] * self._cells_per_dim[0] + cell_ind[0]
+
+        return cell_ind
+
+    def _triangle_areas(self, tri_indices: mi.UInt):
+        meas_surface = self._meas_surface
+        prim_index = meas_surface.face_indices(tri_indices)
+        v0 = meas_surface.vertex_position(prim_index[0])
+        v1 = meas_surface.vertex_position(prim_index[1])
+        v2 = meas_surface.vertex_position(prim_index[2])
+        return dr.norm(dr.cross(v1 - v0, v2 - v0)) / 2
+
+
+    def _resample_tensor(self, tensor: mi.TensorXf, res: mi.Point2u):
+        if tensor.ndim != 2:
+            raise ValueError("_resample_tensor requires tensor to be 2D.")
+        # The resample() function needs this to be the scalar type
+        res = mi.ScalarPoint2u(res.x[0], res.y[0])
+        bitmap = mi.Bitmap(tensor, mi.Bitmap.PixelFormat.Y)
         resampled = mi.TensorXf(bitmap.resample(res))
-        self._elevation = dr.reshape(mi.TensorXf, resampled, res.yx)
+        return dr.reshape(mi.TensorXf, resampled, res)

--- a/src/sionna/rt/radio_map_solvers/dem_radio_map.py
+++ b/src/sionna/rt/radio_map_solvers/dem_radio_map.py
@@ -5,6 +5,7 @@ import drjit as dr
 
 from .radio_map import RadioMap
 from sionna.rt.utils.geometry import triangulate_elevation
+from sionna.rt.constants import EPSILON_FLOAT
 from typing import List, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -128,7 +129,8 @@ class DemRadioMap(RadioMap):
             (dr.arange(mi.UInt, size=cells_per_dim_y) + 0.5) / cells_per_dim_y
         )
         scaled_uv = self.size * mi.Point2f(u, v)
-        ray_origin = mi.Point3f(scaled_uv.x, scaled_uv.y, 0)
+        min_z = self.measurement_surface.bbox().min.z - EPSILON_FLOAT
+        ray_origin = mi.Point3f(scaled_uv.x, scaled_uv.y, min_z)
         ray = mi.Ray3f(o=ray_origin, d=mi.Point3f(0, 0, 1))
         # It makes more sense to use eval_parameterization() here, but that
         # segfaults for common inputs (cause unknown). This is a workaround

--- a/src/sionna/rt/radio_map_solvers/dem_radio_map.py
+++ b/src/sionna/rt/radio_map_solvers/dem_radio_map.py
@@ -90,7 +90,7 @@ class DemRadioMap(RadioMap):
         """
         cells_per_dim = self._cells_per_dim
         return cells_per_dim.x[0] * cells_per_dim.y[0]
-    
+
     @property
     def cell_centers(self):
         r"""Positions of the centers of the cells in the global coordinate
@@ -104,7 +104,16 @@ class DemRadioMap(RadioMap):
             (dr.arange(mi.UInt, size=cells_per_dim_x) + 0.5) / cells_per_dim_x,
             (dr.arange(mi.UInt, size=cells_per_dim_y) + 0.5) / cells_per_dim_y
         )
-        points = self._meas_surface.eval_parameterization(mi.Point2f(u, v))
+        scaled_uv = self.size * mi.Point2f(u, v)
+        ray_origin = mi.Point3f(scaled_uv.x, scaled_uv.y, 0)
+        ray = mi.Ray3f(o=ray_origin, d=mi.Point3f(0, 0, 1))
+        # It makes more sense to use eval_parameterization() here, but that
+        # segfaults for common inputs (cause unknown). This is a workaround
+        # leveraging the fact that triangulate_elevation() creates texcoords
+        # by flattening the vertices to a unit square in the XY plane. This 
+        # will not work if elevation values are negative.
+        scene = mi.load_dict({"type": "scene", "mesh": self._meas_surface})
+        points = scene.ray_intersect(ray).p
         shape = (self._cells_per_dim.y[0], self._cells_per_dim.x[0], 3)
         return dr.reshape(mi.TensorXf, points, shape)
 

--- a/src/sionna/rt/radio_map_solvers/dem_radio_map.py
+++ b/src/sionna/rt/radio_map_solvers/dem_radio_map.py
@@ -58,20 +58,9 @@ class DemRadioMap(MeshRadioMap):
         meas_surface = triangulate_elevation(elevation)
         center = mi.Point3f(center)
         orientation = mi.Point3f(orientation)
-        orientation_deg = orientation * 180. / dr.pi
         size = mi.Point2f(size)
-        to_world = mi.Transform4f().translate(center) \
-                                .rotate([0., 0., 1.], orientation_deg.x) \
-                                .rotate([0., 1., 0.], orientation_deg.y) \
-                                .rotate([1., 0., 0.], orientation_deg.z) \
-                                .scale([0.5 * size.x, 0.5 * size.y, 1])
-        params = mi.traverse(meas_surface)
-        # Apply the to_world transformation
-        vertices = dr.reshape(mi.Point3f, params["vertex_positions"], (3, -1))
-        vertices = to_world @ vertices
-        params["vertex_positions"] = dr.ravel(vertices)
+        # TODO respect the frame
 
-        params.update()
         super().__init__(scene, meas_surface=meas_surface)
 
         self._elevation = elevation
@@ -141,9 +130,13 @@ class DemRadioMap(MeshRadioMap):
 
         :type: :py:class:`mi.TensorXf [cells_per_dim_y, cells_per_dim_x, 3]`
         """
-        # TODO create UV coordinates in a unit grid with the correct number of cells
-        grid = ...
-        points = self._meas_surface.eval_parameterization(grid)
+        cells_per_dim_x = self._cells_per_dim.x[0]
+        cells_per_dim_y = self._cells_per_dim.y[0]
+        u, v = dr.meshgrid(
+            (dr.arange(mi.UInt, size=cells_per_dim_x) + 0.5) / cells_per_dim_x,
+            (dr.arange(mi.UInt, size=cells_per_dim_y) + 0.5) / cells_per_dim_y
+        )
+        points = self._meas_surface.eval_parameterization(mi.Point2f(u, v))
         shape = (self._cells_per_dim.y[0], self._cells_per_dim.x[0], 3)
         return dr.reshape(mi.TensorXf, points, shape)
 
@@ -167,29 +160,40 @@ class DemRadioMap(MeshRadioMap):
         grid_shape = (self.num_tx, cells_per_dim_y, cells_per_dim_x)
         pathgain_map_grid = dr.zeros(mi.TensorXf, shape=grid_shape)
 
-        num_faces = len(pathgain_map.array)
-        upper_indices = dr.arange(mi.UInt, start=0, stop=num_faces // 2)
-        lower_indices = dr.arange(mi.UInt, start=num_faces // 2, stop=num_faces)
-        # [num_tx * cells_per_dim_y * cells_per_dim_x]
-        all_grid_indices = dr.arange(mi.UInt, size=len(pathgain_map_grid.array))
-        # [num_tx * cells_per_dim_y * cells_per_dim_x]
-        upper_face_values = dr.gather(mi.Float, pathgain_map.array, upper_indices)
-        # [num_tx * cells_per_dim_y * cells_per_dim_x]
-        lower_face_values = dr.gather(mi.Float, pathgain_map.array, lower_indices)
-        # TODO make this work for multiple transmitters
-        dr.scatter_add(target=pathgain_map_grid.array,
-                       value=upper_face_values,
-                       index=all_grid_indices,
-                       active=~dr.isnan(upper_face_values))
-        dr.scatter_add(target=pathgain_map_grid.array,
-                       value=lower_face_values,
-                       index=all_grid_indices,
-                       active=~dr.isnan(lower_face_values))
-        # [num_tx * cells_per_dim_y * cells_per_dim_x]
-        count = dr.zeros(mi.TensorXu, grid_shape)
-        dr.scatter_add(count.array, 1, all_grid_indices, ~dr.isnan(upper_face_values))
-        dr.scatter_add(count.array, 1, all_grid_indices, ~dr.isnan(lower_face_values))
-        pathgain_map_grid /= count
+        num_faces = 2 * self.cells_count
+        # TODO vectorize this over transmitters
+        for tx in range(self.num_tx):
+            idx = mi.UInt(tx * num_faces)
+            upper_indices = idx + dr.arange(mi.UInt, 0, num_faces // 2)
+            lower_indices = idx + dr.arange(mi.UInt, num_faces // 2, num_faces)
+            all_grid_indices = idx + dr.arange(mi.UInt, size=self.cells_count)
+            # [num_tx * cells_per_dim_y * cells_per_dim_x]
+            upper_face_values = dr.gather(dtype=mi.Float,
+                                          source=pathgain_map.array,
+                                          index=upper_indices)
+            # [num_tx * cells_per_dim_y * cells_per_dim_x]
+            lower_face_values = dr.gather(dtype=mi.Float,
+                                          source=pathgain_map.array,
+                                          index=lower_indices)
+            dr.scatter_add(target=pathgain_map_grid.array,
+                           value=upper_face_values,
+                           index=all_grid_indices,
+                           active=~dr.isnan(upper_face_values))
+            dr.scatter_add(target=pathgain_map_grid.array,
+                           value=lower_face_values,
+                           index=all_grid_indices,
+                           active=~dr.isnan(lower_face_values))
+            # [num_tx * cells_per_dim_y * cells_per_dim_x]
+            count = dr.zeros(mi.TensorXu, grid_shape)
+            dr.scatter_add(target=count.array,
+                           value=1,
+                           index=all_grid_indices,
+                           active=~dr.isnan(upper_face_values))
+            dr.scatter_add(target=count.array,
+                           value=1,
+                           index=all_grid_indices,
+                           active=~dr.isnan(lower_face_values))
+            pathgain_map_grid /= count
         self._pathgain_map = pathgain_map_grid
 
     def resample(self, resolution: mi.Point2u):

--- a/src/sionna/rt/radio_map_solvers/radio_map_solver.py
+++ b/src/sionna/rt/radio_map_solvers/radio_map_solver.py
@@ -381,7 +381,6 @@ class RadioMapSolver:
                                     elevation=digital_elevation_model,
                                     cell_size=cell_size,
                                     center=center,
-                                    orientation=orientation,
                                     size=size)
             measurement_surface = radio_map.measurement_surface
             modified_scene = extend_scene_with_mesh(scene.mi_scene, measurement_surface)

--- a/src/sionna/rt/radio_map_solvers/radio_map_solver.py
+++ b/src/sionna/rt/radio_map_solvers/radio_map_solver.py
@@ -368,14 +368,14 @@ class RadioMapSolver:
 
         # Build Radio Map instance
         # Modify the scene for non-planar radio maps.
-        if measurement_surface and digital_elevation_model:
+        if measurement_surface is not None and digital_elevation_model is not None:
             raise ValueError("At most one of `measurement_surface` and `digital_elevation_model` can be provided.")
-        elif measurement_surface:
+        elif measurement_surface is not None:
             if isinstance(measurement_surface, SceneObject):
                 measurement_surface = measurement_surface.mi_mesh
             modified_scene = extend_scene_with_mesh(scene.mi_scene, measurement_surface)
             radio_map = MeshRadioMap(scene, measurement_surface)
-        elif digital_elevation_model:
+        elif digital_elevation_model is not None:
             radio_map = DemRadioMap(scene, digital_elevation_model)
             measurement_surface = radio_map.measurement_surface
             modified_scene = extend_scene_with_mesh(scene.mi_scene, measurement_surface)

--- a/src/sionna/rt/radio_map_solvers/radio_map_solver.py
+++ b/src/sionna/rt/radio_map_solvers/radio_map_solver.py
@@ -18,6 +18,7 @@ from sionna.rt.scene import extend_scene_with_mesh
 from .radio_map import RadioMap
 from .planar_radio_map import PlanarRadioMap
 from .mesh_radio_map import MeshRadioMap
+from .dem_radio_map import DemRadioMap
 
 
 class RadioMapSolver:
@@ -219,6 +220,7 @@ class RadioMapSolver:
         size : mi.Point2f | None = None,
         cell_size : mi.Point2f = mi.Point2f(10, 10),
         measurement_surface : mi.Shape | SceneObject | None = None,
+        digital_elevation_model : mi.TensorXf | None = None,
         precoding_vec : Tuple[mi.TensorXf, mi.TensorXf] | None = None,
         samples_per_tx : int = 1000000,
         max_depth : int = 3,
@@ -265,6 +267,13 @@ class RadioMapSolver:
         :param measurement_surface: Measurement surface. If set, the
             radio map is computed for this surface, where every triangle in the
             mesh is a cell in the radio map.
+            If set to `None`, then the radio map is computed for a measurement
+            grid defined by ``center``, ``orientation``, ``size``, and ``cell_size``.
+
+        :param digital_elevation_model: Digital Elevation Model (DEM). If set, 
+            the provided DEM is triangulated, the radio map is computed on that
+            surface, and the results are rearranged back into a grid with the
+            same shape as the provided DEM. 
             If set to `None`, then the radio map is computed for a measurement
             grid defined by ``center``, ``orientation``, ``size``, and ``cell_size``.
 
@@ -358,14 +367,18 @@ class RadioMapSolver:
         self._sampler.seed(seed, num_samples)
 
         # Build Radio Map instance
-        # If a measurement surface is provided, then it is a mesh radio map.
-        # Moreover, in this case, the Mitsuba scene is modified by adding the
-        # measurement surface to the scene.
-        if measurement_surface is not None:
+        # Modify the scene for non-planar radio maps.
+        if measurement_surface and digital_elevation_model:
+            raise ValueError("At most one of `measurement_surface` and `digital_elevation_model` can be provided.")
+        elif measurement_surface:
             if isinstance(measurement_surface, SceneObject):
                 measurement_surface = measurement_surface.mi_mesh
             modified_scene = extend_scene_with_mesh(scene.mi_scene, measurement_surface)
             radio_map = MeshRadioMap(scene, measurement_surface)
+        elif digital_elevation_model:
+            radio_map = DemRadioMap(scene, digital_elevation_model)
+            measurement_surface = radio_map.measurement_surface
+            modified_scene = extend_scene_with_mesh(scene.mi_scene, measurement_surface)
         else:
             modified_scene = scene.mi_scene
             radio_map = PlanarRadioMap(scene, cell_size, center, orientation, size)

--- a/src/sionna/rt/radio_map_solvers/radio_map_solver.py
+++ b/src/sionna/rt/radio_map_solvers/radio_map_solver.py
@@ -271,9 +271,8 @@ class RadioMapSolver:
             grid defined by ``center``, ``orientation``, ``size``, and ``cell_size``.
 
         :param digital_elevation_model: Digital Elevation Model (DEM). If set, 
-            the provided DEM is triangulated, the radio map is computed on that
-            surface, and the results are rearranged back into a grid with the
-            same shape as the provided DEM. 
+            the provided DEM is triangulated, the radio map is computed on a 
+            grid draped over the resulting mesh.
             If set to `None`, then the radio map is computed for a measurement
             grid defined by ``center``, ``orientation``, ``size``, and ``cell_size``.
 
@@ -376,7 +375,6 @@ class RadioMapSolver:
             modified_scene = extend_scene_with_mesh(scene.mi_scene, measurement_surface)
             radio_map = MeshRadioMap(scene, measurement_surface)
         elif digital_elevation_model is not None:
-            # measurement_surface = triangulate_elevation(digital_elevation_model)
             radio_map = DemRadioMap(scene=scene,
                                     elevation=digital_elevation_model,
                                     cell_size=cell_size,

--- a/src/sionna/rt/radio_map_solvers/radio_map_solver.py
+++ b/src/sionna/rt/radio_map_solvers/radio_map_solver.py
@@ -9,7 +9,7 @@ import drjit as dr
 from typing import Tuple, Callable, List
 
 from sionna.rt.utils import spawn_ray_from_sources, fibonacci_lattice,\
-    rotation_matrix, spectrum_to_matrix_4f
+    rotation_matrix, spectrum_to_matrix_4f, triangulate_elevation
 from sionna.rt import Scene
 from sionna.rt.antenna_pattern import antenna_pattern_to_world_implicit
 from sionna.rt.constants import InteractionType
@@ -376,6 +376,7 @@ class RadioMapSolver:
             modified_scene = extend_scene_with_mesh(scene.mi_scene, measurement_surface)
             radio_map = MeshRadioMap(scene, measurement_surface)
         elif digital_elevation_model is not None:
+            # measurement_surface = triangulate_elevation(digital_elevation_model)
             radio_map = DemRadioMap(scene, digital_elevation_model)
             measurement_surface = radio_map.measurement_surface
             modified_scene = extend_scene_with_mesh(scene.mi_scene, measurement_surface)

--- a/src/sionna/rt/radio_map_solvers/radio_map_solver.py
+++ b/src/sionna/rt/radio_map_solvers/radio_map_solver.py
@@ -9,7 +9,7 @@ import drjit as dr
 from typing import Tuple, Callable, List
 
 from sionna.rt.utils import spawn_ray_from_sources, fibonacci_lattice,\
-    rotation_matrix, spectrum_to_matrix_4f, triangulate_elevation
+    rotation_matrix, spectrum_to_matrix_4f
 from sionna.rt import Scene
 from sionna.rt.antenna_pattern import antenna_pattern_to_world_implicit
 from sionna.rt.constants import InteractionType
@@ -377,7 +377,12 @@ class RadioMapSolver:
             radio_map = MeshRadioMap(scene, measurement_surface)
         elif digital_elevation_model is not None:
             # measurement_surface = triangulate_elevation(digital_elevation_model)
-            radio_map = DemRadioMap(scene, digital_elevation_model)
+            radio_map = DemRadioMap(scene=scene,
+                                    elevation=digital_elevation_model,
+                                    cell_size=cell_size,
+                                    center=center,
+                                    orientation=orientation,
+                                    size=size)
             measurement_surface = radio_map.measurement_surface
             modified_scene = extend_scene_with_mesh(scene.mi_scene, measurement_surface)
         else:

--- a/src/sionna/rt/scene.py
+++ b/src/sionna/rt/scene.py
@@ -487,7 +487,11 @@ class Scene:
         if show_devices:
             fig.plot_radio_devices(show_orientations=show_orientations)
         if radio_map is not None:
-            if isinstance(radio_map, sionna.rt.MeshRadioMap):
+            if isinstance(radio_map, sionna.rt.DemRadioMap):
+                fig.plot_dem_radio_map(
+                    radio_map, tx=rm_tx, db_scale=rm_db_scale,
+                    vmin=rm_vmin, vmax=rm_vmax, metric=rm_metric)
+            elif isinstance(radio_map, sionna.rt.MeshRadioMap):
                 fig.plot_mesh_radio_map(
                     radio_map, tx=rm_tx, db_scale=rm_db_scale,
                     vmin=rm_vmin, vmax=rm_vmax, metric=rm_metric)

--- a/src/sionna/rt/utils/geometry.py
+++ b/src/sionna/rt/utils/geometry.py
@@ -111,19 +111,23 @@ def rotation_matrix(angles : mi.Point3f) -> mi.Matrix3f:
 
     return rot_mat
 
-def triangulate_elevation(elevation: mi.TensorXf) -> mi.Mesh:
-    # Treat elevation data as values at the centers of cells. We want the
-    # corners. The corners are the average of the surrounding centers
-    padded = np.pad(elevation.numpy(), 1, constant_values=float("nan"))
-    windows = sliding_window_view(padded, window_shape=(2, 2), axis=(0, 1))
-    elevation = np.nanmean(windows, axis=(-1, -2))
+def triangulate_elevation(
+        elevation: mi.TensorXf,
+        center: mi.Point3f,
+        size: mi.Point2f
+) -> mi.Mesh:
     num_rows, num_cols = elevation.shape
     vertices_x, vertices_y = dr.meshgrid(
         dr.linspace(mi.Float, 0, 1, num_cols),
         dr.linspace(mi.Float, 0, 1, num_rows)
     )
-    vertices = mi.Point3f(vertices_x, vertices_y, elevation.ravel())
+    vertices = mi.Point3f(vertices_x, vertices_y, dr.ravel(elevation))
+    # Transform vertices after projecting to define texcoords
+    center = mi.Point3f(center)
+    size = mi.Point2f(size)
     texcoords = vertices.xy
+    vertices.xy *= size
+    vertices += center
 
     vertex_indices = dr.arange(mi.UInt, num_rows * num_cols)
     faces_count = 2 * (num_rows - 1) * (num_cols - 1)
@@ -132,13 +136,10 @@ def triangulate_elevation(elevation: mi.TensorXf) -> mi.Mesh:
     is_last_row = vertex_indices // num_cols == num_rows - 1
     ii = dr.compress(~is_last_column & ~is_last_row)
     first_half_mask = dr.arange(mi.UInt, faces_count) < faces_count / 2
-    # TODO verify that this isn't backwards?
     dr.scatter(target=faces,
-            #    value=mi.Vector3u(ii, ii + 1, ii + num_cols + 1),
                value=mi.Vector3u(ii, ii + num_cols + 1, ii + 1),
                index=dr.compress(first_half_mask))
     dr.scatter(target=faces,
-            #    value=mi.Vector3u(ii, ii + num_cols + 1, ii + num_cols),
                value=mi.Vector3u(ii, ii + num_cols, ii + num_cols + 1),
                index=dr.compress(~first_half_mask))
 

--- a/src/sionna/rt/utils/geometry.py
+++ b/src/sionna/rt/utils/geometry.py
@@ -108,3 +108,38 @@ def rotation_matrix(angles : mi.Point3f) -> mi.Matrix3f:
                            [r_31, r_32, r_33]])
 
     return rot_mat
+
+def triangulate_elevation(elevation: mi.TensorXf) -> mi.Mesh:
+    num_rows, num_cols = elevation.shape
+    vertices_x, vertices_y = dr.meshgrid(
+        dr.linspace(mi.Float, 0, 1, num_cols),
+        dr.linspace(mi.Float, 0, 1, num_rows)
+    )
+    vertices = mi.Point3f(vertices_x, vertices_y, dr.ravel(elevation))
+    texcoords = vertices.xy
+
+    vertex_indices = dr.arange(mi.UInt, num_rows * num_cols)
+    faces_count = 2 * (num_rows - 1) * (num_cols - 1)
+    faces = dr.empty(mi.Vector3u, faces_count)
+    is_last_column = (vertex_indices + 1) % num_cols == 0
+    is_last_row = vertex_indices // num_cols == num_rows - 1
+    ii = dr.compress(~is_last_column & ~is_last_row)
+    first_half_mask = dr.arange(mi.UInt, faces_count) < faces_count / 2
+    dr.scatter(target=faces,
+               value=mi.Vector3u(ii, ii + 1, ii + num_cols + 1),
+               index=dr.compress(first_half_mask))
+    dr.scatter(target=faces,
+               value=mi.Vector3u(ii, ii + num_cols + 1, ii + num_cols),
+               index=dr.compress(~first_half_mask))
+
+    mesh = mi.Mesh(name="triangulated_elevation",
+                   face_count=dr.width(faces),
+                   vertex_count=dr.width(vertices),
+                   has_vertex_texcoords=True)
+    params = mi.traverse(mesh)
+    params["vertex_positions"] = dr.ravel(vertices)
+    params["vertex_texcoords"] = dr.ravel(texcoords)
+    params["faces"] = dr.ravel(faces)
+    params.update()
+
+    return mesh

--- a/src/sionna/rt/utils/geometry.py
+++ b/src/sionna/rt/utils/geometry.py
@@ -134,10 +134,12 @@ def triangulate_elevation(elevation: mi.TensorXf) -> mi.Mesh:
     first_half_mask = dr.arange(mi.UInt, faces_count) < faces_count / 2
     # TODO verify that this isn't backwards?
     dr.scatter(target=faces,
-               value=mi.Vector3u(ii, ii + 1, ii + num_cols + 1),
+            #    value=mi.Vector3u(ii, ii + 1, ii + num_cols + 1),
+               value=mi.Vector3u(ii, ii + num_cols + 1, ii + 1),
                index=dr.compress(first_half_mask))
     dr.scatter(target=faces,
-               value=mi.Vector3u(ii, ii + num_cols + 1, ii + num_cols),
+            #    value=mi.Vector3u(ii, ii + num_cols + 1, ii + num_cols),
+               value=mi.Vector3u(ii, ii + num_cols, ii + num_cols + 1),
                index=dr.compress(~first_half_mask))
 
     mesh = mi.Mesh(name="triangulated_elevation",

--- a/src/sionna/rt/utils/geometry.py
+++ b/src/sionna/rt/utils/geometry.py
@@ -7,8 +7,6 @@
 import drjit as dr
 import mitsuba as mi
 from typing import Tuple
-import numpy as np
-from numpy.lib.stride_tricks import sliding_window_view
 
 
 def phi_hat(phi : mi.Float) -> mi.Vector3f:

--- a/src/sionna/rt/utils/geometry.py
+++ b/src/sionna/rt/utils/geometry.py
@@ -7,6 +7,8 @@
 import drjit as dr
 import mitsuba as mi
 from typing import Tuple
+import numpy as np
+from numpy.lib.stride_tricks import sliding_window_view
 
 
 def phi_hat(phi : mi.Float) -> mi.Vector3f:
@@ -110,12 +112,17 @@ def rotation_matrix(angles : mi.Point3f) -> mi.Matrix3f:
     return rot_mat
 
 def triangulate_elevation(elevation: mi.TensorXf) -> mi.Mesh:
+    # Treat elevation data as values at the centers of cells. We want the
+    # corners. The corners are the average of the surrounding centers
+    padded = np.pad(elevation.numpy(), 1, constant_values=float("nan"))
+    windows = sliding_window_view(padded, window_shape=(2, 2), axis=(0, 1))
+    elevation = np.nanmean(windows, axis=(-1, -2))
     num_rows, num_cols = elevation.shape
     vertices_x, vertices_y = dr.meshgrid(
         dr.linspace(mi.Float, 0, 1, num_cols),
         dr.linspace(mi.Float, 0, 1, num_rows)
     )
-    vertices = mi.Point3f(vertices_x, vertices_y, dr.ravel(elevation))
+    vertices = mi.Point3f(vertices_x, vertices_y, elevation.ravel())
     texcoords = vertices.xy
 
     vertex_indices = dr.arange(mi.UInt, num_rows * num_cols)
@@ -125,6 +132,7 @@ def triangulate_elevation(elevation: mi.TensorXf) -> mi.Mesh:
     is_last_row = vertex_indices // num_cols == num_rows - 1
     ii = dr.compress(~is_last_column & ~is_last_row)
     first_half_mask = dr.arange(mi.UInt, faces_count) < faces_count / 2
+    # TODO verify that this isn't backwards?
     dr.scatter(target=faces,
                value=mi.Vector3u(ii, ii + 1, ii + num_cols + 1),
                index=dr.compress(first_half_mask))

--- a/src/sionna/rt/utils/render.py
+++ b/src/sionna/rt/utils/render.py
@@ -356,6 +356,39 @@ def radio_map_to_emissive_shape(radio_map: rt.RadioMap, tx: int | None,
             'emitter': emitter,
         }
 
+    elif isinstance(radio_map, rt.DemRadioMap):
+        # rm_values has per-cell values that need to get applied as a texture.
+        # This works because triangulate_elevation() also assigned texcoords.
+        texture, opacity = radio_map_texture(
+            rm_values, db_scale=db_scale, vmin=vmin, vmax=vmax)
+        bsdf = {
+            'type': 'mask',
+            'opacity': {
+                'type': 'bitmap',
+                'bitmap': mi.Bitmap(opacity.astype(np.float32)),
+                "filter_type": "nearest"
+            },
+            'nested': {
+                'type': 'diffuse',
+                'reflectance': 0.,
+            },
+        }
+
+        emitter = {
+            'type': 'area',
+            'radiance': {
+                'type': 'bitmap',
+                'bitmap': mi.Bitmap(texture.astype(np.float32)),
+                "filter_type": "nearest"
+            },
+        }
+
+        props = mi.Properties()
+        props['bsdf'] = mi.load_dict(bsdf)
+        props['emitter'] = mi.load_dict(emitter)
+        cloned_shape = clone_mesh(radio_map.measurement_surface, props=props)
+        return cloned_shape
+
     elif isinstance(radio_map, rt.MeshRadioMap):
         # rm_values has per-triangle values for the requested tx and metric.
         texture, opacity = radio_map_texture(

--- a/test/unit/test_radio_maps.py
+++ b/test/unit/test_radio_maps.py
@@ -13,7 +13,7 @@ import pytest
 import sionna.rt as rt
 from sionna.rt import load_scene, Transmitter, PlanarArray, ITURadioMaterial,\
     Receiver, PathSolver, RadioMapSolver, BackscatteringPattern
-from sionna.rt.utils import dbm_to_watt, load_mesh, transform_mesh
+from sionna.rt.utils import dbm_to_watt, load_mesh, transform_mesh, triangulate_elevation, clone_mesh
 
 
 ####################################################
@@ -594,6 +594,85 @@ def test_mesh_radio_map(los):
 
     nmse_db = 10*np.log10(np.mean( ((rm.path_gain[0]-a)/a)**2 ))
     assert nmse_db < -20
+
+def test_dem_radio_map():
+    # Create terrain mesh with a bump in the middle
+    vert_x, vert_y = np.meshgrid(np.linspace(0, 10, 100),
+                                 np.linspace(0, 10, 100),
+                                 indexing="xy")
+    elevation = np.exp(-((vert_x-5)**2 + (vert_y-5)**2)) / 5
+    terrain_mesh = triangulate_elevation(elevation=mi.TensorXf(elevation),
+                                           center=[0, 0, 0],
+                                           size=[1, 1])
+    # Add to a dynamically defined scene
+    props = mi.Properties()
+    # Use a non-concrete material to test transmission
+    props["bsdf"] = rt.ITURadioMaterial("mat", itu_type="glass", thickness=1)
+    props["bsdf"] = rt.HolderMaterial(props)
+    terrain_mesh = clone_mesh(terrain_mesh, name="terrain", props=props)
+    scene = rt.Scene(mi.load_dict({
+        "type": "scene",
+        "terrain": terrain_mesh
+    }))
+
+    scene.tx_array = default_array()
+    scene.rx_array = default_array(polarization="VH")
+    tx = rt.Transmitter(name="tx",
+                    position=mi.Point3f(.2, .2, 0.1),
+                    orientation=mi.Point3f(0,0,0))
+    tx.display_radius = 0.01
+    scene.add(tx)
+
+    rm_solver = rt.RadioMapSolver()
+    sim_params = {
+        "specular_reflection": True,
+        "diffuse_reflection": True,
+        "refraction": True,
+        "max_depth": 5,
+    }
+    # Compute the radio map as a DEM
+    rm_dem = rm_solver(scene=scene,
+                       center=[0, 0, 0],
+                       size=[1, 1],
+                       cell_size=[0.01, 0.01],
+                       # evaluate 5cm above the surface
+                       digital_elevation_model=mi.TensorXf(elevation) + 0.05,
+                       samples_per_tx=int(1e8),
+                       **sim_params)
+    # Compute the radio map as a mesh
+    rm_mesh = rm_solver(scene=scene,
+                        center=[0, 0, 0],
+                        size=[1, 1],
+                        measurement_surface=rm_dem.measurement_surface,
+                        samples_per_tx=int(1e8),
+                        **sim_params)
+    
+    # Re-assemble mesh radio map values into a grid
+    meas_surface = rm_mesh.measurement_surface
+    num_faces = meas_surface.face_count()
+    faces = meas_surface.faces_buffer().numpy().reshape(-1, 3)
+    vertices = meas_surface.vertex_positions_buffer().numpy().reshape(-1, 3)
+    tris = vertices[faces]
+    v0, v1, v2 = tris[:, 0, :], tris[:, 1, :], tris[:, 2, :]
+    tri_areas = np.linalg.norm(np.cross(v1 - v0, v2 - v0), axis=-1) / 2
+    # This indexing is tightly coupled to triangulate_elevation()
+    tri_areas_u = tri_areas[:num_faces // 2]
+    tri_areas_d = tri_areas[num_faces // 2:]
+    cell_areas = tri_areas_u + tri_areas_d
+    pg_mesh_u = rm_mesh.path_gain[0][:num_faces // 2]
+    pg_mesh_d = rm_mesh.path_gain[0][num_faces // 2:]
+    # Reweight values based on relative triangle area
+    pg_mesh = (pg_mesh_u * tri_areas_u + pg_mesh_d * tri_areas_d) / cell_areas
+    pg_mesh = pg_mesh.numpy().reshape(100, 100)
+
+    # Compare against DEM radio map values
+    pg_dem = rm_dem.path_gain[0].numpy()
+    with np.errstate(invalid="ignore"):
+        # Silence warning from 0/0 (those values become zero anyway)
+        err = np.where(pg_mesh == 0.0, 0.0, np.abs(pg_mesh - pg_dem) / pg_mesh)
+    nmse_db = 10 * np.log10(np.mean(np.abs(err)**2))
+    assert nmse_db < -20
+
 
 @pytest.mark.parametrize("color_map", [None, np.random.rand(30, 3)])
 def test_show_association(color_map):


### PR DESCRIPTION
Adds a new subclass of `RadioMap` called `DemRadioMap`, which is used to compute Radio Maps on Digital Elevation Models (DEMs, aka heightmaps). While some of this functionality could be mimicked with `MeshRadioMap`, we found it convenient to have a Radio Map class and helper functions that abstract away the resampling, triangulation, and rearrangement into a grid.

This PR also adds a test case, modifies the visualization methods (render and preview) to support `DemRadioMap` objects, and updates Radio Map documentation.