### PR TITLE
Add scene cleanup

### DIFF
--- a/src/sionna/rt/scene.py
+++ b/src/sionna/rt/scene.py
@@ -328,6 +328,9 @@ class Scene:
                 raise ValueError(f"Cannot remove the radio material '{name}'"
                                   " because it is still used by at least one"
                                   " object")
+
+            # Allow the radio material to be reused in another scene
+            self._radio_materials[name]._scene = None
             del self._radio_materials[name]
         elif isinstance(item, Transmitter):
             del self._transmitters[name]

--- a/src/sionna/rt/scene.py
+++ b/src/sionna/rt/scene.py
@@ -1315,11 +1315,18 @@ def edit_scene_shapes(
 
         for v in remove:
             if isinstance(v, SceneObject):
+                v._scene = None
+                if isinstance(v.radio_material, RadioMaterialBase):
+                    v.radio_material._scene = None
+
                 v = v.mi_mesh
 
             if isinstance(v, str):
                 o = scene.objects.get(v)
                 if o:
+                    o._scene = None
+                    if isinstance(o.radio_material, RadioMaterialBase):
+                        o.radio_material._scene = None
                     mi_id = o.mi_mesh.id()
                     ids_to_remove.add(mi_id)
             elif isinstance(v, mi.Shape):

--- a/src/sionna/rt/scene.py
+++ b/src/sionna/rt/scene.py
@@ -364,6 +364,20 @@ class Scene:
             to be added
         """
 
+        # Sanity check for the inputs
+        if add is not None:
+            if isinstance(add, (mi.Object, dict, SceneObject)):
+                add = [add]
+
+            # Check SceneObject is not used in another scene
+            for a in add:
+                if isinstance(a, SceneObject):
+                    if a._scene is not None and a._scene is not self:
+                        raise ValueError(f"Cannot add the object '{a.name}'"
+                                         " because it is already part of"
+                                         " another scene")
+
+
         # Set the Mitsuba scene to the edited scene
         self._scene = edit_scene_shapes(self, add=add, remove=remove)
         # Reset the scene params
@@ -374,8 +388,6 @@ class Scene:
         # the users valid
         scene_objects = self._scene_objects
         if add is not None:
-            if isinstance(add, sionna.rt.SceneObject):
-                add = [add]
             scene_objects.update({o.name : o for o in add})
         self._scene_objects = {}
         for s in self._scene.shapes():

--- a/src/sionna/rt/scene.py
+++ b/src/sionna/rt/scene.py
@@ -408,11 +408,10 @@ class Scene:
 
         for so in self.objects.values():
             so._scene = None
-            if isinstance(so.radio_material, RadioMaterialBase):
-                so.radio_material.remove_object()
+            so.radio_material._scene = None
 
-        for mat in self.radio_materials:
-            self.remove(mat)
+        for mat in self.radio_materials.values():
+            mat._scene = None
 
     def preview(self, *,
         background: str=DEFAULT_PREVIEW_BACKGROUND_COLOR,

--- a/src/sionna/rt/scene.py
+++ b/src/sionna/rt/scene.py
@@ -389,6 +389,10 @@ class Scene:
         # Reset the preview widget to ensure the preview is redraw
         self.scene_geometry_updated()
 
+    def close(self):
+        for mat in self.radio_materials:
+            self.remove(mat)
+
     def preview(self, *,
         background: str=DEFAULT_PREVIEW_BACKGROUND_COLOR,
         clip_at: float | None=None,

--- a/src/sionna/rt/scene.py
+++ b/src/sionna/rt/scene.py
@@ -401,7 +401,16 @@ class Scene:
         # Reset the preview widget to ensure the preview is redraw
         self.scene_geometry_updated()
 
-    def close(self):
+    def close(self) -> None:
+        r"""
+        Closes the scene and releases all scene objects and radio materials
+        """
+
+        for so in self.objects.values():
+            so._scene = None
+            if isinstance(so.radio_material, RadioMaterialBase):
+                so.radio_material.remove_object()
+
         for mat in self.radio_materials:
             self.remove(mat)
 

--- a/test/unit/test_scene.py
+++ b/test/unit/test_scene.py
@@ -86,7 +86,7 @@ def test_scene_close_and_reuse_scene_object():
     s1.close()
 
     # Check radio material is removed from s1
-    assert box_mat._count_using_objects == 0
+    assert box_mat._count_using_objects == 1
     assert box_mat.scene is None
 
     # Check box is removed from s1
@@ -164,4 +164,27 @@ def test_scene_object_and_radio_material():
 
     s2 = sionna.rt.Scene()
     s2.edit(add=so)
+    assert so.radio_material._count_using_objects == 1
+
+
+def test_scene_object_and_radio_material_after_scene_close():
+    fname = os.path.join(os.path.dirname(__file__), "../data/subdivided_cube.ply")
+
+    s1 = sionna.rt.Scene()
+    mat = ITURadioMaterial("test-material", "concrete", 1.0)
+    assert mat._count_using_objects == 0
+
+    so = SceneObject(fname=fname, name="test-object", radio_material=mat)
+    assert so.radio_material._count_using_objects == 1
+
+    s1.edit(add=so)
+    assert so.radio_material._count_using_objects == 1
+
+    # Close s1
+    s1.close()
+    assert so.radio_material._count_using_objects == 1
+
+    s2 = sionna.rt.Scene()
+    s2.edit(add=so)
+    s2.close()
     assert so.radio_material._count_using_objects == 1

--- a/test/unit/test_scene.py
+++ b/test/unit/test_scene.py
@@ -10,6 +10,9 @@ import sionna
 from sionna.rt import load_scene, SceneObject, ITURadioMaterial
 
 
+TEST_DUPLICATE_MATERIAL = ITURadioMaterial("test-duplicate-material", "concrete", 1.0)
+
+
 def test_scene_close_and_reuse_radio_material():
     s1 = sionna.rt.Scene()
     s2 = sionna.rt.Scene()
@@ -93,3 +96,24 @@ def test_scene_close_and_reuse_scene_object():
     assert len(s2.mi_scene.shapes()) == 1
     assert box.scene == s2
     assert box_mat.scene == s2
+
+
+def test_scene_auto_remove_1():
+    s1 = sionna.rt.Scene()
+
+    s1.add(TEST_DUPLICATE_MATERIAL)
+
+
+def test_scene_auto_remove_2():
+    s1 = sionna.rt.Scene()
+
+    # Should failed, we don't have __del__ to finalize the scene
+    with pytest.raises(ValueError):
+        s1.add(TEST_DUPLICATE_MATERIAL)
+
+    TEST_DUPLICATE_MATERIAL._scene = None
+    s1.add(TEST_DUPLICATE_MATERIAL)
+
+    assert TEST_DUPLICATE_MATERIAL.scene == s1
+    s1.close()
+    assert TEST_DUPLICATE_MATERIAL.scene is None

--- a/test/unit/test_scene.py
+++ b/test/unit/test_scene.py
@@ -1,0 +1,48 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import pytest
+import drjit as dr
+import mitsuba as mi
+import sionna
+from sionna.rt import load_scene, SceneObject, ITURadioMaterial
+
+
+def test_scene_close_and_reuse_radio_material():
+    s1 = sionna.rt.Scene()
+    s2 = sionna.rt.Scene()
+
+    # Add m1 to s1
+    m1 = ITURadioMaterial("m1", "concrete", 1.0)
+    s1.add(m1)
+
+    with pytest.raises(ValueError):
+        # Should not be able to add the same material twice to the same scene
+        s2.add(m1)
+
+    # Should have the ability to "close" the scene
+    s1.close()
+
+    # Should allow to add the radio material to another scene
+    s2.add(m1)
+
+
+def test_scene_remove_radio_material():
+    s1 = sionna.rt.Scene()
+    s2 = sionna.rt.Scene()
+
+    # Add m1 to s1
+    m1 = ITURadioMaterial("m1", "concrete", 1.0)
+    s1.add(m1)
+
+    with pytest.raises(ValueError):
+        # Should not be able to add the same material twice to the same scene
+        s2.add(m1)
+
+    # Remove it from s1
+    s1.remove("m1")
+
+    # Should allow to add the radio material to another scene
+    s2.add(m1)

--- a/test/unit/test_scene.py
+++ b/test/unit/test_scene.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import os
+
 import pytest
 import drjit as dr
 import mitsuba as mi
@@ -117,3 +119,49 @@ def test_scene_auto_remove_2():
     assert TEST_DUPLICATE_MATERIAL.scene == s1
     s1.close()
     assert TEST_DUPLICATE_MATERIAL.scene is None
+
+
+def test_scene_edit_remove():
+    s1 = load_scene(sionna.rt.scene.box_one_screen, merge_shapes=False)
+    s2 = sionna.rt.Scene()
+
+    box = s1.objects["box"]
+    with pytest.raises(ValueError):
+        s2.edit(add=box)
+
+    s1.edit(remove="box")
+    assert "box" not in s1.objects
+    assert box.scene is None
+    assert box.radio_material is not None
+    assert box.radio_material._count_using_objects == 1
+    assert box.radio_material.scene is None
+    assert len(s1.mi_scene.shapes()) == 1  # only screen remains
+
+    s2.edit(add=box)
+    assert box.scene == s2
+    assert box.radio_material is not None
+    assert box.radio_material._count_using_objects == 1
+    assert box.radio_material.scene == s2
+    assert len(s2.mi_scene.shapes()) == 1
+
+
+def test_scene_object_and_radio_material():
+    fname = os.path.join(os.path.dirname(__file__), "../data/subdivided_cube.ply")
+
+    s1 = sionna.rt.Scene()
+    mat = ITURadioMaterial("test-material", "concrete", 1.0)
+    assert mat._count_using_objects == 0
+
+    so = SceneObject(fname=fname, name="test-object", radio_material=mat)
+    assert so.radio_material._count_using_objects == 1
+
+    s1.edit(add=so)
+    assert so.radio_material._count_using_objects == 1
+
+    s1.edit(remove="test-object")
+    assert so.radio_material._count_using_objects == 1
+    assert so.scene is None
+
+    s2 = sionna.rt.Scene()
+    s2.edit(add=so)
+    assert so.radio_material._count_using_objects == 1

--- a/test/unit/test_scene.py
+++ b/test/unit/test_scene.py
@@ -59,3 +59,37 @@ def test_scene_edit_should_not_add_scene_object_if_has_scene():
         s2.edit(add=box)
 
     assert len(s2.mi_scene.shapes()) == 0
+
+
+def test_scene_close_and_reuse_scene_object():
+    s1 = load_scene(sionna.rt.scene.box_one_screen, merge_shapes=False)
+    s2 = sionna.rt.Scene()
+
+    box = s1.objects["box"]
+    box_mat = box.radio_material
+
+    with pytest.raises(ValueError):
+        s2.add(box_mat)
+
+    with pytest.raises(ValueError):
+        s2.edit(add=box)
+
+    # Should not add box's mi_mesh into s2 since it belongs to s1
+    assert len(s2.mi_scene.shapes()) == 0
+
+    # Close s1
+    s1.close()
+
+    # Check radio material is removed from s1
+    assert box_mat._count_using_objects == 0
+    assert box_mat.scene is None
+
+    # Check box is removed from s1
+    assert box.scene is None
+    assert box.radio_material == box_mat
+
+    # Should allow to add the radio material to another scene
+    s2.edit(add=box)
+    assert len(s2.mi_scene.shapes()) == 1
+    assert box.scene == s2
+    assert box_mat.scene == s2

--- a/test/unit/test_scene.py
+++ b/test/unit/test_scene.py
@@ -46,3 +46,16 @@ def test_scene_remove_radio_material():
 
     # Should allow to add the radio material to another scene
     s2.add(m1)
+
+
+def test_scene_edit_should_not_add_scene_object_if_has_scene():
+    s1 = load_scene(sionna.rt.scene.box_one_screen, merge_shapes=False)
+    s2 = sionna.rt.Scene()
+
+    assert len(s2.mi_scene.shapes()) == 0
+
+    box = s1.objects["box"]
+    with pytest.raises(ValueError):
+        s2.edit(add=box)
+
+    assert len(s2.mi_scene.shapes()) == 0


### PR DESCRIPTION
It's difficult to reuse `SceneObject` or `RadioMaterial` because currently `sionna.rt.Scene()` does not provide a method to cleanup/close the scene.

This PR add the needed handling for this, including:

- scene.close()
- scene.add(RadioMaterialBase)
- scene.remove(RadioMaterialBase)
- scene.edit(add=so)
- scene.edit(remove=so)