### PR TITLE
Fix `.preview()` print out legend object when not in IPython shell

### DIFF
--- a/src/sionna/rt/preview.py
+++ b/src/sionna/rt/preview.py
@@ -10,6 +10,7 @@ import numpy as np
 from ipywidgets import widgets
 from ipywidgets.embed import embed_snippet
 import pythreejs as p3s
+from IPython.core.interactiveshell import InteractiveShell
 from IPython.display import display
 import matplotlib as mpl
 
@@ -585,8 +586,11 @@ class Previewer:
             value=f"<div style='{style}'></div> {label}")
                          for label, style in legend_items]
         legend = widgets.VBox(legend_labels)
-        # Display the renderer and legend together
-        display(widgets.HBox([self._renderer, legend]))
+
+        # Check if we are in a IPython interactive shell
+        if InteractiveShell.initialized():
+            # Display the renderer and legend together
+            display(widgets.HBox([self._renderer, legend]))
 
     ##################################################
     # Accessors


### PR DESCRIPTION
This commit check if there is an IPython interactive shell before we call `display()` in `.show_legend()` to prevent that object print

When calling `Scene.preview()`, if it calls `fig.show_legend()` without an IPython interactive shell, it will then print out the legend object to stdout, spamming the output:

```
   >>> import sionna.rt
   >>> s = sionna.rt.load_scene(sionna.rt.scene.munich)
   >>> s.preview()
   HBox(children=(Renderer(camera=PerspectiveCamera(aspect=1.31, ...
   <sionna.rt.preview.Previewer object at 0x7fb394457190>
   >>>
```

This is because at the last line of `.show_legend()`, we use `IPython.display.display()` to try to show the legend, and `display()` will print out objects if it is not in a IPython interactive shell:

```python
   def display(...):
       from IPython.core.interactiveshell import InteractiveShell

       if not InteractiveShell.initialized():
           # Directly print objects.
           print(*objs)
           return
```