### PR TITLE
Bugfix for sample_data.py in realease v1.2.0

### DIFF
--- a/src/sionna/rt/path_solvers/sample_data.py
+++ b/src/sionna/rt/path_solvers/sample_data.py
@@ -112,8 +112,12 @@ class SampleData:
         shapes = dr.reinterpret_array(mi.UInt, shapes)
 
         # Store data in the buffer
-        data = SampleData.SampleDataFields(interaction_types, shapes,
-                                           primitives, vertices, probs)
+        data = SampleData.SampleDataFields(dr.detach(interaction_types), 
+                                           dr.detach(shapes),
+                                           dr.detach(primitives),
+                                           dr.detach(vertices), 
+                                           dr.detach(probs))
+        
         self._local_mem.write(data, index, active=active)
 
         # Store the local edge index and edge properties


### PR DESCRIPTION
With new release v1.2.0 calibrating radio parameters taken from the example [https://nvlabs.github.io/sionna/rt/developer/dev_custom_radio_materials.html](https://nvlabs.github.io/sionna/rt/developer/dev_custom_radio_materials.html) results in the following error code:

```
File /usr/local/lib/python3.10/dist-packages/sionna/rt/path_solvers/sample_data.py:118, in SampleData.insert(self, depth, interaction_types, shapes, primitives, diffracting_wedges, vertices, probs, active)
    115 data = SampleData.SampleDataFields(interaction_types, shapes,
    116                                    primitives, vertices, probs)
--> 118 self._local_mem.write(data, index, active=active)
    120 # Store the local edge index and edge properties

RuntimeError: Local memory writes are not differentiable. You must use 'drjit.detach()' to disable gradient tracking of the written value.
```

Providing bugfix for above error.