### PR TITLE
Added: Check if name of scene material is None

### DIFF
--- a/src/sionna/rt/scene_utils.py
+++ b/src/sionna/rt/scene_utils.py
@@ -65,6 +65,9 @@ def process_xml(xml_string: str,
 
         # Ensure compatibility with Sionna v0.x ITU radio materials
         name = mat_id
+	if name is None:
+            bsdf_string = ET.tostring(bsdf, encoding='unicode')
+            raise ValueError(f"Found bsdf without name: {bsdf_string[:100]}")
         if name.startswith("mat-"):
             name = name[4:]
         if name.startswith("itu_") or name.startswith("itu-"):

--- a/src/sionna/rt/scene_utils.py
+++ b/src/sionna/rt/scene_utils.py
@@ -65,7 +65,7 @@ def process_xml(xml_string: str,
 
         # Ensure compatibility with Sionna v0.x ITU radio materials
         name = mat_id
-	if name is None:
+		if name is None:
             bsdf_string = ET.tostring(bsdf, encoding='unicode')
             raise ValueError(f"Found bsdf without name: {bsdf_string[:100]}")
         if name.startswith("mat-"):


### PR DESCRIPTION
Adding an error message telling the user which (truncated) XML element caused the error.

Avoids throwing error ```Before, a AttributeError: 'NoneType' object has no attribute 'startswith'```

Fixed minor type.