### PR TITLE
fix(docs): small typo in introduction tutorial

### DIFF
--- a/tutorials/Introduction.ipynb
+++ b/tutorials/Introduction.ipynb
@@ -735,7 +735,7 @@
    "id": "ef5a9bc2-b183-4fcd-8788-2c77136b32ac",
    "metadata": {},
    "source": [
-    "Note that the delay of the first arriving path is by default normalized to zero. This behavior can be changed by setting the argument ``normalize_delays`` to `True`.\n",
+    "Note that the delay of the first arriving path is by default normalized to zero. This behavior can be changed by setting the argument ``normalize_delays`` to `False`.\n",
     "\n",
     "We can obtain the channel frequency response in a similar manner:"
    ]


### PR DESCRIPTION
Hi! I found this small typo while reading your docs: I guess you meant to say `False` here :-)