### PR TITLE
fix(docs): update syntax in custom antenna pattern example

### DIFF
--- a/doc/source/developer/dev_custom_antenna_patterns.rst
+++ b/doc/source/developer/dev_custom_antenna_patterns.rst
@@ -190,7 +190,7 @@ antenna patterns.
 
     # Switch the computation of field loop to "evaluated" mode to
     # enable gradient backpropagation through the loop
-    solver.field_calculator.loop_mode = "evaluated"
+    solver.loop_mode = "evaluated"
 
     # Compute propagation paths
     paths = solver(scene, max_depth=0)
@@ -201,9 +201,9 @@ antenna patterns.
 
     # Compute gradients
     dr.backward(power)
-    print(opt.variables["theta_t"].grad)
-    print(opt.variables["phi_t"].grad)
-    print(opt.variables["lambda"].grad)
+    print(opt["theta_t"].grad)
+    print(opt["phi_t"].grad)
+    print(opt["lambda"].grad)
 
 ::
 


### PR DESCRIPTION
Hi, when I tried to implement this example, I noticed that the provided code failed to run. After searching through Mitsuba's documentation and your code base, I concluded that this tutorial probably uses old syntax that is no longer valid.

One suggestion: wouldn't it make more sense to compute the gradient with respect to the negative power to show the direction of maximum power?

Thanks for this amazing tool :-)