### PR TITLE
fix(docs): remove spurious vertical scrollbar on display equations

### DIFF
--- a/doc/source/_static/css/sionna.css
+++ b/doc/source/_static/css/sionna.css
@@ -61,3 +61,10 @@ div.math {
     overflow-x: auto;
     overflow-y: hidden;
 }
+
+/* MathJax v4 (Sphinx 9): keep horizontal scroll for wide equations,
+   but suppress the spurious vertical scrollbar next to each equation */
+div.math mjx-container {
+    overflow-x: auto;
+    overflow-y: hidden;
+}


### PR DESCRIPTION
## Summary

Display equations in the standalone Sionna RT documentation render with a small, spurious vertical scrollbar.

**Cause:** With the current Sphinx 9 / MathJax v4 setup, `pydata-sphinx-theme` applies `overflow: auto` to MathJax containers. A sub-pixel height mismatch between the theme and MathJax fonts then triggers a vertical scrollbar on display equations.

**Fix:** Override the theme for display equations using the scoped `div.math mjx-container` selector. Set `overflow-y: hidden` to suppress vertical scrollbars and `overflow-x: auto` to preserve horizontal scrolling for wide equations.

The existing `.MathJax_Display` rule targets MathJax v2 markup and no longer applies.

## Changes

- `doc/source/_static/css/sionna.css`: add scoped overflow handling for MathJax display-equation containers.

## Testing

Rebuilt the standalone Sionna RT documentation and verified that display equations on the EM primer page no longer show vertical scrollbars, while wide equations remain horizontally scrollable.