### PR TITLE
fix(em): incorrect diffraction matrix in `RadioMaterial`

### DIFF
--- a/src/sionna/rt/radio_materials/radio_material.py
+++ b/src/sionna/rt/radio_materials/radio_material.py
@@ -1078,16 +1078,17 @@ class RadioMaterial(RadioMaterialBase):
         w_n_out = jones_matrix_rotator(ko_local, e_r_s_n_hat, phi_hat)
 
         # Compute fresnel coefficients for both faces
+        wavelength = dr.two_pi / wavenumber
         r_te_0, r_tm_0, _, _ =\
             itu_coefficients_single_layer_slab(dr.abs(dr.sin(phi_prime)),
                                                eta,
                                                self._d,
-                                               wavenumber)
+                                               wavelength)
         r_te_n, r_tm_n, _, _ =\
             itu_coefficients_single_layer_slab(dr.abs(dr.sin(exterior_angle-phi)),
                                                eta,
                                                self._d,
-                                               wavenumber)
+                                               wavelength)
         #
         # Construct R_0 and R_n matrices
         #

--- a/test/unit/test_radio_maps.py
+++ b/test/unit/test_radio_maps.py
@@ -518,7 +518,7 @@ def test_diffraction_street_canyon():
                             diffraction=True,
                             diffraction_lit_region=True)
 
-    rx_indices = [(120, 120), (160, 50), (160, 150), (120, 200), (220, 100),
+    rx_indices = [(120, 120), (170, 50), (160, 60), (120, 200), (220, 100),
                   (175, 350)]
     for i, p in enumerate(rx_indices):
         rx_pos = rmap.cell_centers[p[0], p[1]]


### PR DESCRIPTION
Hi, I believe I found a bug in the diffraction/UTD implementation where the diffraction-only coverage maps are missing the Reflection Shadow Boundaries (RSBs), which should normally be visible alongside the Incident Shadow Boundaries (ISBs).

# Context

For the context, Enrico M. Vitucci (who reviewed my PhD manuscript) commented that the diffraction-only coverage maps I included in my manuscript were missing the RSBs but not the ISBs. As I used Sionna-RT for those figures, I recently investigated this problem and I believe I have found the root cause of this issue.

# Details

In `_diffraction_matrix` (inside `radio_material.py`), `itu_coefficients_single_layer_slab` was called with `wavenumber` ($2\pi / \lambda$) as the fourth argument instead of the `wavelength` ($\lambda$). Passing `wavenumber` instead of `wavelength` scales down the parameter by an important factor. driving the reflection coefficients to nearly 0, which scales down all reflection-dependent UTD terms and completely hides the RSBs from the coverage maps.

I fixed this by calculating the wavelength and passing it correctly to the helper function.

* Before:
<img width="1776" height="1210" alt="diffraction_coverage_before" src="https://github.com/user-attachments/assets/ca218d17-294a-41c9-a58e-e6f195347f63" />


* After wavelength fix:
<img width="1776" height="1210" alt="diffraction_coverage_wavelength_fix" src="https://github.com/user-attachments/assets/8419c75a-37e6-4717-bc3e-b9c33160d28f" />

> [!NOTE]
> In `test_radio_maps.py` (`test_diffraction_street_canyon`), I updated two receiver indices to shift them slightly away from the shadow boundaries:
> * Before the fix, the reflection coefficients were flat and near-zero, meaning the solvers agreed by coincidence.
> * Once the shadow boundaries were correctly restored, the fields introduced steep transitions. Because `RadioMapSolver` averages power over a cell grid ($0.5\text{ m} \times 0.5\text{ m}$) while `PathSolver` evaluates the exact center point, the two solvers naturally diverge on shadow boundaries.
> * Shifting the receiver indices slightly away from the boundaries avoids this resolution-related averaging discrepancy and ensures a robust and passing unit test.

## MWE

```python
 import matplotlib.pyplot as plt
import drjit as dr
import sionna.rt
import sionna.rt.radio_materials.radio_material as rm_mod

# Keep track of the original function
original_itu = rm_mod.itu_coefficients_single_layer_slab

def run_simulation(buggy=False):
    # Load the street canyon scene
    sionna_scene = sionna.rt.load_scene(sionna.rt.scene.simple_street_canyon)
    sionna_scene.frequency = 28e9

    # Setup transmitter and receiver arrays
    sionna_scene.tx_array = sionna.rt.PlanarArray(
        num_rows=1,
        num_cols=1,
        vertical_spacing=0.5,
        horizontal_spacing=0.5,
        pattern="iso",
        polarization="V",
    )
    sionna_scene.rx_array = sionna_scene.tx_array

    tx = [-33, 11, 32]
    sionna_scene.add(sionna.rt.Transmitter(name="tx", position=tx, orientation=[0, 0, 0]))

    if buggy:
        # Wrap the itu function to pass wavenumber instead of wavelength
        # Since wavelength = 2*pi/wavenumber, wavenumber = 2*pi/wavelength
        def buggy_itu(cos_theta, eta, d, wavelength):
            buggy_wavelength = dr.two_pi / wavelength
            return original_itu(cos_theta, eta, d, buggy_wavelength)
        rm_mod.itu_coefficients_single_layer_slab = buggy_itu
    else:
        rm_mod.itu_coefficients_single_layer_slab = original_itu

    # Compute radio map using diffraction-only
    rm_solver = sionna.rt.RadioMapSolver()
    rm_diffr = rm_solver(
        scene=sionna_scene,
        los=False,
        specular_reflection=False,
        refraction=False,
        diffraction=True,
        max_depth=3,
        cell_size=[0.1, 0.1],
        samples_per_tx=int(1e7),
    )

    # Restore function
    rm_mod.itu_coefficients_single_layer_slab = original_itu

    return rm_diffr

# 1. Generate Before Fix (Buggy)
rm_before = run_simulation(buggy=True)
fig_before = rm_before.show(metric="path_gain", tx=0, vmin=-140, vmax=-60)
plt.savefig("diffraction_coverage_before.png", bbox_inches="tight", dpi=300)

# 2. Generate After Fix (Correct)
rm_after = run_simulation(buggy=False)
fig_after = rm_after.show(metric="path_gain", tx=0, vmin=-140, vmax=-60)
plt.savefig("diffraction_coverage_wavelength_fix.png", bbox_inches="tight", dpi=300)
```

---

Let me know if you have any questions or feedback!